### PR TITLE
chore: improve code formatting and lint tools before commit

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,38 +17,39 @@ on:
   pull_request:
   pull_request_target:
     types: [labeled]
+
 jobs:
   build:
     if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
     name: build and unit test
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.19'
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - name: make build
-        run: make build
-      - name: make test
-        run: make test
-      - name: Remove PR Label
-        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                name: 'tests: run',
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number
-              });
-            } catch (e) {
-              console.log('Failed to remove label. Another job may have already removed it!');
-            }
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.19'
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+    - name: make build
+      run: make build
+    - name: make test
+      run: make test
+    - name: Remove PR Label
+      if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          try {
+            await github.rest.issues.removeLabel({
+              name: 'tests: run',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
+          } catch (e) {
+            console.log('Failed to remove label. Another job may have already removed it!');
+          }

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -17,39 +17,42 @@ on:
   pull_request:
   pull_request_target:
     types: [labeled]
+
 jobs:
   lint:
     if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
     name: run lint
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.19'
-      - name: Install goimports
-        run: go install golang.org/x/tools/cmd/goimports@latest
-      - name: Checkout code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.pull_request.head.sha }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-      - run: make github_lint
-      - name: Verify no changes from goimports and go mod tidy. If you're reading this and the check has failed, run `make pre_commit`.
-        run: git diff --exit-code
-      - name: Remove PR Label
-        if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
-        uses: actions/github-script@v6
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          script: |
-            try {
-              await github.rest.issues.removeLabel({
-                name: 'tests: run',
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                issue_number: context.payload.pull_request.number
-              });
-            } catch (e) {
-              console.log('Failed to remove label. Another job may have already removed it!');
-            }
+    - name: Setup Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.19'
+    - name: Install goimports
+      run: go install golang.org/x/tools/cmd/goimports@latest
+    - name: Checkout code
+      uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.sha }}
+        repository: ${{ github.event.pull_request.head.repo.full_name }}
+    - run: goimports -w .
+    - run: go mod tidy
+    - run: make generate manifests
+    - name: Verify no changes from goimports and go mod tidy. If you're reading this and the check has failed, run `goimports -w . && go mod tidy`.
+      run: git diff --exit-code
+    - name: Remove PR Label
+      if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
+      uses: actions/github-script@v6
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        script: |
+          try {
+            await github.rest.issues.removeLabel({
+              name: 'tests: run',
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number
+            });
+          } catch (e) {
+            console.log('Failed to remove label. Another job may have already removed it!');
+          }

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ pre_commit: git_workdir_clean build add_copyright_header go_fmt ## Run all the f
 
 .PHONY: git_workdir_clean
 git_workdir_clean: # Checks if the git working directory is clean. Fails if there are unstaged changes.
-	git diff --quiet || (echo "git working directory has unstaged changes. "; echo "Add or stash all changes before you commit."; exit 1)
+	git diff --exit-code --stat || (echo "git working directory has unstaged changes. "; echo "Add or stash all changes before you commit."; exit 1)
 
 
 .PHONY: add_pre_commit_hook ## run checks to make sure boilerplate workflows will pass


### PR DESCRIPTION
Adds adds a new makefile target `make pre_commit` which will format all the code and make sure that the git
working directory is clean before the developer can commit. This will help ensure that all golang (and eventually Yaml)
files can pass the lint check. 

Also adds new makefile target `make add_pre_commit_hook` which developers may use to automatically run 
`make pre_commit` automatically before committing code.