### PR TITLE
feat: Add logic to apply the AuthProxyWorkload to kubernetes workloads

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	k8s.io/apimachinery v0.24.2
 	k8s.io/client-go v0.24.2
 	sigs.k8s.io/controller-runtime v0.12.2
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -75,5 +76,4 @@ require (
 	k8s.io/utils v0.0.0-20220210201930-3a6ce19ff2f9 // indirect
 	sigs.k8s.io/json v0.0.0-20211208200746-9f7c6b3444d2 // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.1 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/internal/names/names.go
+++ b/internal/names/names.go
@@ -1,0 +1,77 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package names contains functions that help format safe names for
+// kubernetes resources, following the rfc1035/rfc1123 label (DNS_LABEL) format.
+package names
+
+import (
+	"fmt"
+	"hash/fnv"
+	"strings"
+
+	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/api/v1alpha1"
+)
+
+const maxNameLen = 63
+const hashLen = 8
+const dividerLen = 2
+
+// ContainerPrefix is the name prefix used on containers added to PodSpecs
+// by this operator.
+const ContainerPrefix = "csql-"
+
+// ContainerName generates a valid name for a corev1.Container object that
+// implements this cloudsql instance. Names must be 63 characters or less and
+// adhere to the rfc1035/rfc1123 label (DNS_LABEL) format.  r.ObjectMeta.Name
+// already is required to be 63 characters or less because it is a name. Because
+// we are prepending 'csql-' ContainerPrefix as a marker, the generated name with
+// the prefix could be longer than 63 characters.
+func ContainerName(r *cloudsqlapi.AuthProxyWorkload) string {
+	return SafePrefixedName(ContainerPrefix, r.GetName())
+}
+
+func VolumeName(r *cloudsqlapi.AuthProxyWorkload, inst *cloudsqlapi.InstanceSpec, mountType string) string {
+	connName := strings.ReplaceAll(strings.ToLower(inst.ConnectionString), ":", "-")
+	return SafePrefixedName(ContainerPrefix, r.GetName()+"-"+mountType+"-"+connName)
+}
+
+// SafePrefixedName adds a prefix to a name and shortens it while preserving its uniqueness
+// so that it fits the 63 character limit imposed by kubernetes.
+// Kubernetes names must follow the DNS Label format for all names.
+// See https://kubernetes.io/docs/concepts/overview/working-with-objects/names/#rfc-1035-label-names
+func SafePrefixedName(prefix string, name string) string {
+	containerPrefixLen := len(prefix)
+	truncateLen := (maxNameLen - hashLen - dividerLen - containerPrefixLen) / 2
+
+	instName := name
+	if len(instName)+containerPrefixLen > maxNameLen {
+		// string shortener that will still produce a name that is still unique
+		// even though it is truncated.
+		namePrefix := instName[:truncateLen]
+		nameSuffix := instName[len(instName)-truncateLen:]
+		checksum := hash(instName)
+		return strings.ToLower(fmt.Sprintf("%s%s-%s-%x", prefix, namePrefix, nameSuffix, checksum))
+	} else {
+		return strings.ToLower(fmt.Sprintf("%s%s", prefix, instName))
+	}
+
+}
+
+// hash simply returns the checksum for a string
+func hash(s string) uint32 {
+	h := fnv.New32a()
+	h.Write([]byte(s))
+	return h.Sum32()
+}

--- a/internal/names/names_test.go
+++ b/internal/names/names_test.go
@@ -1,0 +1,107 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package names_test
+
+import (
+	"testing"
+
+	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/api/v1alpha1"
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/names"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestSafeDnsLabel(t *testing.T) {
+	t.Parallel()
+	tcs := []struct {
+		desc string
+		want string
+		name string
+	}{
+		{
+			desc: "short name",
+			name: "instance1",
+			want: "csql-instance1",
+		},
+		{
+			desc: "max length name truncates to safe length",
+			name: "twas-brillig-and-the-slithy-toves-did-gyre-and-gimble-in-the-wa",
+			want: "csql-twas-brillig-and-the-sli-yre-and-gimble-in-the-wa-e398b76e",
+		},
+		{
+			desc: "just barely too long name truncates to safe length",
+			name: "twas-brillig-and-the-slithy-toves-did-gyre-and-gimble-in-th",
+			want: "csql-twas-brillig-and-the-sli-id-gyre-and-gimble-in-th-78bfbd48",
+		},
+		{
+			desc: "acceptable length long name is left whole",
+			name: "twas-brillig-and-the-slithy-toves-did-gyre-and-gimble-in-t",
+			want: "csql-twas-brillig-and-the-slithy-toves-did-gyre-and-gimble-in-t",
+		},
+		{
+			desc: "truncated difference in middle preserved in hash 1",
+			name: "twas-brillig-and-the-slithy-toves-1111-did-gyre-and-gimble-in",
+			want: "csql-twas-brillig-and-the-sli-1-did-gyre-and-gimble-in-d0b9860",
+		},
+		{
+			desc: "truncated difference in middle preserved in hash 2",
+			name: "twas-brillig-and-the-slithy-toves-2222-did-gyre-and-gimble-in",
+			want: "csql-twas-brillig-and-the-sli-2-did-gyre-and-gimble-in-34c209d4",
+		},
+	}
+	for _, tc := range tcs {
+		t.Run(tc.desc, func(t *testing.T) {
+			got := names.SafePrefixedName("csql-", tc.name)
+			if got != tc.want {
+				t.Errorf("want %v. got %v", tc.want, got)
+			}
+			if len(got) > 63 {
+				t.Errorf("want len(containerName) <= 63. got %v", len(got))
+			}
+		})
+	}
+
+}
+
+// TestContainerName container names are a public
+func TestContainerName(t *testing.T) {
+	csql := mustMakeCsql("hello-world", "default")
+	got := names.ContainerName(csql)
+	want := "csql-hello-world"
+	if want != got {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+}
+
+func mustMakeCsql(name string, namespace string) *cloudsqlapi.AuthProxyWorkload {
+	// Create a CloudSqlInstance that matches the deployment
+	return &cloudsqlapi.AuthProxyWorkload{
+		TypeMeta:   metav1.TypeMeta{Kind: "AuthProxyWorkload", APIVersion: cloudsqlapi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace},
+		Spec: cloudsqlapi.AuthProxyWorkloadSpec{
+			Workload: cloudsqlapi.WorkloadSelectorSpec{
+				Kind: "",
+				Name: "",
+				Selector: &metav1.LabelSelector{
+					MatchLabels:      map[string]string{"app": "hello"},
+					MatchExpressions: nil,
+				},
+			},
+			Instances: []cloudsqlapi.InstanceSpec{{ConnectionString: "proj:inst:db"}},
+		},
+		Status: cloudsqlapi.AuthProxyWorkloadStatus{},
+	}
+
+}

--- a/internal/podspec_updates.go
+++ b/internal/podspec_updates.go
@@ -1,0 +1,513 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/api/v1alpha1"
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/names"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+)
+
+// ErrorCodePortConflict occurs when an explicit port assignment for a workload
+// is in conflict with a port assignment from the pod or another workload.
+const ErrorCodePortConflict = "PortConflict"
+const ErrorCodeEnvConflict = "EnvVarConflict"
+const ErrorCodeFUSENotSupported = "FUSENotSupported"
+const DefaultFirstPort int32 = 5000
+const DefaultHealthCheckPort int32 = 9801
+
+type ConfigError struct {
+	workloadKind      schema.GroupVersionKind
+	workloadName      string
+	workloadNamespace string
+
+	details []ConfigErrorDetail
+}
+
+func (c *ConfigError) DetailedErrors() []ConfigErrorDetail {
+	return c.details
+}
+
+func (err *ConfigError) Error() string {
+	return fmt.Sprintf("found %d configuration errors on workload %s %s/%s: %v",
+		len(err.details),
+		err.workloadKind.String(),
+		err.workloadNamespace,
+		err.workloadName,
+		err.details)
+}
+
+func (err *ConfigError) add(errorCode, description string, proxy *cloudsqlapi.AuthProxyWorkload) {
+	err.details = append(err.details,
+		ConfigErrorDetail{
+			WorkloadKind:       err.workloadKind,
+			WorkloadName:       err.workloadName,
+			WorkloadNamespace:  err.workloadNamespace,
+			AuthProxyNamespace: proxy.GetNamespace(),
+			AuthProxyName:      proxy.GetName(),
+			ErrorCode:          errorCode,
+			Description:        description,
+		})
+}
+
+type ConfigErrorDetail struct {
+	ErrorCode          string
+	Description        string
+	AuthProxyName      string
+	AuthProxyNamespace string
+
+	WorkloadKind      schema.GroupVersionKind
+	WorkloadName      string
+	WorkloadNamespace string
+}
+
+func (err *ConfigErrorDetail) Error() string {
+	return fmt.Sprintf("error %s %s while applying AuthProxyWorkload %s/%s to workload  %s %s/%s",
+		err.ErrorCode,
+		err.Description,
+		err.AuthProxyNamespace,
+		err.AuthProxyName,
+		err.WorkloadKind.String(),
+		err.WorkloadNamespace,
+		err.WorkloadName)
+
+}
+
+type updateState struct {
+	err             ConfigError
+	portsInUse      []int32
+	workloadEnvVars []corev1.EnvVar
+	nextDbPort      int32
+	volumeMounts    []corev1.VolumeMount
+	volumes         []corev1.Volume
+}
+
+func (state *updateState) addVolumeMount(mnt corev1.VolumeMount, vol corev1.Volume) {
+	state.volumeMounts = append(state.volumeMounts, mnt)
+	state.volumes = append(state.volumes, vol)
+}
+
+// addInUsePort Adds a new port to the list of ports in use
+func (state *updateState) addInUsePort(port int32) {
+	state.portsInUse = append(state.portsInUse, port)
+}
+
+// isPortInUse checks if the port is in use
+func (state *updateState) isPortInUse(port int32) bool {
+	for i := 0; i < len(state.portsInUse); i++ {
+		if port == state.portsInUse[i] {
+			return true
+		}
+	}
+	return false
+}
+
+func (state *updateState) useNextDbPort() int32 {
+	for state.isPortInUse(state.nextDbPort) {
+		state.nextDbPort++
+	}
+	state.addInUsePort(state.nextDbPort)
+	return state.nextDbPort
+}
+
+// addWorkloadEnvVar adds or replaces the envVar based on its Name, returning the old and new values
+func (state *updateState) addWorkloadEnvVar(envVar corev1.EnvVar, proxy *cloudsqlapi.AuthProxyWorkload) {
+	for i := 0; i < len(state.workloadEnvVars); i++ {
+		if state.workloadEnvVars[i].Name == envVar.Name {
+			old := state.workloadEnvVars[i]
+			state.workloadEnvVars[i] = envVar
+			if old.Value != envVar.Value {
+				state.addError(ErrorCodeEnvConflict,
+					fmt.Sprintf("environment variable named %s already exists", envVar.Name), proxy)
+			}
+			return
+		}
+	}
+	state.workloadEnvVars = append(state.workloadEnvVars, envVar)
+	return
+}
+
+// UpdateWorkloadContainers Applies the proxy containers from all of the instances listed in matchingAuthProxyWorkloads to the workload
+func UpdateWorkloadContainers(workload Workload, matchingAuthProxyWorkloads []*cloudsqlapi.AuthProxyWorkload) (bool, *ConfigError) {
+	state := updateState{
+		nextDbPort: DefaultFirstPort,
+		err: ConfigError{
+			workloadKind:      workload.GetObject().GetObjectKind().GroupVersionKind(),
+			workloadName:      workload.GetObject().GetName(),
+			workloadNamespace: workload.GetObject().GetNamespace(),
+		},
+	}
+	return state.update(workload, matchingAuthProxyWorkloads)
+}
+
+func (state *updateState) update(workload Workload, matchingAuthProxyWorkloads []*cloudsqlapi.AuthProxyWorkload) (bool, *ConfigError) {
+
+	podSpec := workload.GetPodSpec()
+	containers := podSpec.Containers
+	updated := false
+
+	//TODO maybe replace with regular for loop style go
+	nonProxyContainers := fnFilter[corev1.Container](containers,
+		func(t corev1.Container) bool {
+			return strings.Index(t.Name, names.ContainerPrefix) != 0
+		})
+
+	state.portsInUse = fnFlatMap[corev1.Container, int32](
+		nonProxyContainers,
+		func(t corev1.Container) []int32 {
+			return fnMap[corev1.ContainerPort, int32](t.Ports, func(t corev1.ContainerPort) int32 {
+				return t.ContainerPort
+			})
+		})
+
+	// add all new containers and update existing containers
+	for i, _ := range matchingAuthProxyWorkloads {
+		inst := matchingAuthProxyWorkloads[i]
+
+		var instContainer *corev1.Container
+
+		for j, _ := range containers {
+			container := &containers[j]
+			if container.Name == names.ContainerName(inst) {
+				instContainer = container
+				break
+			}
+		}
+		if instContainer == nil {
+			newContainer := corev1.Container{}
+			state.UpdateContainer(inst, workload, &newContainer)
+			containers = append(containers, newContainer)
+			updated = true
+		} else {
+			updated = state.UpdateContainer(inst, workload, instContainer)
+		}
+	}
+
+	// remove all csql containers that don't relate to one of the matchingAuthProxyWorkloads
+	var filteredContainers []corev1.Container
+
+	for j, _ := range containers {
+		container := &containers[j]
+		if strings.HasPrefix(container.Name, names.ContainerPrefix) {
+			found := false
+			for i, _ := range matchingAuthProxyWorkloads {
+				if names.ContainerName(matchingAuthProxyWorkloads[i]) == container.Name {
+					found = true
+					break
+				}
+			}
+			if found {
+				filteredContainers = append(filteredContainers, *container)
+			} else {
+				// we're removing a container that doesn't match an csqlWorkload
+				updated = true
+			}
+		} else {
+			filteredContainers = append(filteredContainers, *container)
+		}
+	}
+	podSpec.Containers = filteredContainers
+
+	for i, _ := range podSpec.Containers {
+		state.applyCommonContainerConfig(&podSpec.Containers[i])
+	}
+	state.applyVolumes(&podSpec)
+
+	workload.SetPodSpec(podSpec)
+
+	// only return ConfigError if there were reported
+	// errors during processing.
+	var err *ConfigError
+	if len(state.err.details) > 0 {
+		err = &state.err
+	} else {
+		err = nil
+	}
+	return updated, err
+}
+
+// UpdateContainer Creates or updates the proxy container in the workload's PodSpec
+func (state *updateState) UpdateContainer(proxy *cloudsqlapi.AuthProxyWorkload, workload Workload, container *corev1.Container) bool {
+	doUpdate, status := MarkWorkloadUpdated(proxy, workload)
+
+	if doUpdate {
+		var cliArgs []string
+
+		if proxy.Spec.ProxyContainer != nil && proxy.Spec.ProxyContainer.Container != nil {
+			proxy.Spec.ProxyContainer.Container.DeepCopyInto(container)
+			container.Name = names.ContainerName(proxy)
+		} else {
+			container.Name = names.ContainerName(proxy)
+			container.ImagePullPolicy = "IfNotPresent"
+
+			if proxy.Spec.ProxyContainer != nil && proxy.Spec.ProxyContainer.Image != "" {
+				container.Image = proxy.Spec.ProxyContainer.Image
+			} else {
+				container.Image = DefaultContainerImage
+			}
+
+			if proxy.Spec.ProxyContainer != nil && proxy.Spec.ProxyContainer.Resources != nil {
+				container.Resources = *proxy.Spec.ProxyContainer.Resources.DeepCopy()
+			} else {
+				container.Resources = defaultContainerResources
+			}
+
+			// always enable http port healthchecks
+			cliArgs = append(cliArgs, fmt.Sprintf("--http-port=%d", state.addHealthCheck(proxy)))
+			cliArgs = append(cliArgs, "--health-check")
+			cliArgs = append(cliArgs, "--structured-logs")
+
+			if proxy.Spec.ProxyContainer != nil && proxy.Spec.ProxyContainer.SQLAdminApiEndpoint != "" {
+				cliArgs = append(cliArgs, "--sqladmin-api-endpoint="+proxy.Spec.ProxyContainer.SQLAdminApiEndpoint)
+			}
+			if proxy.Spec.ProxyContainer != nil && proxy.Spec.ProxyContainer.Telemetry != nil {
+				tel := proxy.Spec.ProxyContainer.Telemetry
+				if tel != nil {
+					if tel.TelemetrySampleRate != nil {
+						cliArgs = append(cliArgs, fmt.Sprintf("--telemetry-sample-rate=%d", *tel.TelemetrySampleRate))
+					}
+					if tel.DisableTraces != nil && *tel.DisableTraces {
+						cliArgs = append(cliArgs, "--disable-traces")
+					}
+					if tel.DisableMetrics != nil && *tel.DisableMetrics {
+						cliArgs = append(cliArgs, "--disable-metrics")
+					}
+					if tel.PrometheusNamespace != nil || (tel.Prometheus != nil && *tel.Prometheus) {
+						cliArgs = append(cliArgs, "--prometheus")
+					}
+					if tel.PrometheusNamespace != nil {
+						cliArgs = append(cliArgs, fmt.Sprintf("--prometheus-namespace=%s", *tel.PrometheusNamespace))
+					}
+					if tel.TelemetryProject != nil {
+						cliArgs = append(cliArgs, fmt.Sprintf("--telemetry-project=%s", *tel.TelemetryProject))
+					}
+					if tel.TelemetryPrefix != nil {
+						cliArgs = append(cliArgs, fmt.Sprintf("--telemetry-prefix=%s", *tel.TelemetryPrefix))
+					}
+				}
+			}
+
+			//TODO Authorization
+			// --credentials-file
+
+			for _, inst := range proxy.Spec.Instances {
+
+				params := map[string]string{}
+
+				if inst.SocketType == cloudsqlapi.SocketTypeTCP ||
+					(inst.SocketType == "" && inst.UnixSocketPath == "") {
+					var port int32
+					if inst.Port == nil {
+						port = state.useNextDbPort()
+					} else {
+						port = *inst.Port
+						if state.isPortInUse(port) {
+							state.addError(ErrorCodePortConflict,
+								fmt.Sprintf("proxy port %d for instance %s is already in use",
+									port, inst.ConnectionString), proxy)
+						}
+						state.addInUsePort(port)
+					}
+					params["port"] = fmt.Sprint(port)
+					if inst.HostEnvName != "" {
+						state.addWorkloadEnvVar(corev1.EnvVar{
+							Name:  inst.HostEnvName,
+							Value: "localhost",
+						}, proxy)
+					}
+					if inst.PortEnvName != "" {
+						state.addWorkloadEnvVar(corev1.EnvVar{
+							Name:  inst.PortEnvName,
+							Value: fmt.Sprint(port),
+						}, proxy)
+					}
+				}
+
+				if inst.SocketType == cloudsqlapi.SocketTypeUnix ||
+					(inst.SocketType == "" && inst.UnixSocketPath != "") {
+					params["unix-socket"] = inst.UnixSocketPath
+					mountName := names.VolumeName(proxy, &inst, "unix")
+					state.addVolumeMount(
+						corev1.VolumeMount{
+							Name:      mountName,
+							ReadOnly:  false,
+							MountPath: inst.UnixSocketPath,
+						},
+						corev1.Volume{
+							Name:         mountName,
+							VolumeSource: corev1.VolumeSource{EmptyDir: &corev1.EmptyDirVolumeSource{}},
+						})
+
+					if inst.UnixSocketPathEnvName != "" {
+						state.addWorkloadEnvVar(corev1.EnvVar{
+							Name:  inst.UnixSocketPathEnvName,
+							Value: inst.UnixSocketPath,
+						}, proxy)
+					}
+				}
+
+				if inst.AutoIamAuthn != nil {
+					if *inst.AutoIamAuthn {
+						params["auto-iam-authn"] = "true"
+					} else {
+						params["auto-iam-authn"] = "false"
+					}
+				}
+				if inst.PrivateIp != nil {
+					if *inst.PrivateIp {
+						params["private-ip"] = "true"
+					} else {
+						params["private-ip"] = "false"
+					}
+				}
+				if inst.FusePath != "" {
+					state.addError(ErrorCodeFUSENotSupported, "the FUSE filesystem is not yet supported", proxy)
+
+					//TODO fuse...
+					// if FUSE is used, we need to use the 'buster' or 'alpine' image.
+					// for the proxy container. We can't use the default distroless image.
+					if inst.FuseVolumePathEnvName != "" {
+						state.addWorkloadEnvVar(corev1.EnvVar{
+							Name:  inst.FuseVolumePathEnvName,
+							Value: inst.FusePath,
+						}, proxy)
+					}
+
+				}
+
+				instArgs := []string{}
+				for k, v := range params {
+					instArgs = append(instArgs, fmt.Sprintf("%s=%s", k, v))
+				}
+
+				// sort the param args to make testing easier. params will always be
+				// in a stable order
+				sort.Strings(instArgs)
+
+				if len(instArgs) > 0 {
+					cliArgs = append(cliArgs, fmt.Sprintf("%s?%s", inst.ConnectionString, strings.Join(instArgs, "&")))
+				} else {
+					cliArgs = append(cliArgs, inst.ConnectionString)
+				}
+
+			}
+			container.Args = cliArgs
+		}
+	}
+	l.Info("Updating workload ", "name", workload.GetObject().GetName(),
+		"doUpdate", doUpdate,
+		"status", status)
+
+	return doUpdate
+}
+
+// updateContainerEnv applies global container state to all containers
+func (state *updateState) updateContainerEnv(c *corev1.Container) {
+	for i := 0; i < len(state.workloadEnvVars); i++ {
+		c.Env = appendOrReplace(c.Env, state.workloadEnvVars[i],
+			func(a, b *corev1.EnvVar) bool { return a.Name == b.Name })
+	}
+}
+
+// applyContainerVolumes applies global container state to all containers
+func (state *updateState) applyContainerVolumes(c *corev1.Container) {
+	for i := 0; i < len(state.volumeMounts); i++ {
+		c.VolumeMounts = appendOrReplace(c.VolumeMounts, state.volumeMounts[i],
+			func(a, b *corev1.VolumeMount) bool { return a.Name == b.Name })
+	}
+}
+
+// applyVolumes applies global container state to all containers
+func (state *updateState) applyVolumes(spec *corev1.PodSpec) {
+	for i := 0; i < len(state.volumeMounts); i++ {
+		spec.Volumes = appendOrReplace(spec.Volumes, state.volumes[i],
+			func(a, b *corev1.Volume) bool { return a.Name == b.Name })
+	}
+}
+
+func (state *updateState) applyCommonContainerConfig(c *corev1.Container) {
+	state.updateContainerEnv(c)
+	state.applyContainerVolumes(c)
+}
+
+func (state *updateState) addHealthCheck(csqlWorkload *cloudsqlapi.AuthProxyWorkload) int32 {
+	var port int32
+	if csqlWorkload.Spec.ProxyContainer != nil &&
+		csqlWorkload.Spec.ProxyContainer.Telemetry != nil &&
+		csqlWorkload.Spec.ProxyContainer.Telemetry.HttpPort != nil {
+		port = *csqlWorkload.Spec.ProxyContainer.Telemetry.HttpPort
+		if state.isPortInUse(port) {
+			state.addError(ErrorCodePortConflict,
+				fmt.Sprintf("telemetry httpPort %d is already in use", port), csqlWorkload)
+		}
+	} else {
+		port = DefaultHealthCheckPort
+		for state.isPortInUse(port) {
+			port++
+		}
+		state.addInUsePort(port)
+	}
+	//TODO add healthcheck to podspec
+
+	return port
+}
+
+func (state *updateState) addError(errorCode string, description string, proxy *cloudsqlapi.AuthProxyWorkload) {
+	state.err.add(errorCode, description, proxy)
+}
+
+func appendOrReplace[T any](list []T, value T, isEqual func(*T, *T) bool) []T {
+	for i := 0; i < len(list); i++ {
+		if isEqual(&list[i], &value) {
+			list[i] = value
+			return list
+		}
+	}
+	list = append(list, value)
+	return list
+}
+
+func fnFilter[T any](list []T, test func(T) bool) []T {
+	result := make([]T, 0, len(list))
+	for i := 0; i < len(list); i++ {
+		if test(list[i]) {
+			result = append(result, list[i])
+		}
+	}
+	return result
+}
+
+func fnMap[T any, V any](list []T, apply func(T) V) []V {
+	result := make([]V, len(list))
+	for i := 0; i < len(list); i++ {
+		result[i] = apply(list[i])
+	}
+	return result
+}
+func fnFlatMap[T any, V any](list []T, apply func(T) []V) []V {
+	result := make([]V, 0, len(list))
+	for i := 0; i < len(list); i++ {
+		oneResult := apply(list[i])
+		for j := 0; j < len(oneResult); j++ {
+			result = append(result, oneResult[j])
+		}
+	}
+	return result
+}

--- a/internal/podspec_updates_test.go
+++ b/internal/podspec_updates_test.go
@@ -1,0 +1,927 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal_test
+
+import (
+	"fmt"
+	"reflect"
+	"strconv"
+	"testing"
+
+	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/api/v1alpha1"
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/yaml"
+)
+
+func makeWorkload() *internal.DeploymentWorkload {
+	return &internal.DeploymentWorkload{Deployment: &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "busybox", Labels: map[string]string{"app": "hello"}},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "busybox", Image: "busybox"}},
+				},
+			},
+		},
+	}}
+}
+
+func makeSimpleAuthProxy(name string, connectionString string) *cloudsqlapi.AuthProxyWorkload {
+	return makeAuthProxy(name, []cloudsqlapi.InstanceSpec{{
+		ConnectionString: connectionString,
+	}})
+}
+
+func makeAuthProxy(name string, instances []cloudsqlapi.InstanceSpec) *cloudsqlapi.AuthProxyWorkload {
+	return &cloudsqlapi.AuthProxyWorkload{
+		TypeMeta:   metav1.TypeMeta{Kind: "AuthProxyWorkload", APIVersion: cloudsqlapi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: "default", Generation: 1},
+		Spec: cloudsqlapi.AuthProxyWorkloadSpec{
+			Workload: cloudsqlapi.WorkloadSelectorSpec{
+				Kind: "Deployment",
+				Selector: &metav1.LabelSelector{
+					MatchLabels:      map[string]string{"app": "hello"},
+					MatchExpressions: nil,
+				},
+			},
+			Instances: instances,
+		},
+		Status: cloudsqlapi.AuthProxyWorkloadStatus{},
+	}
+}
+
+func makeProxies(wl *internal.DeploymentWorkload, proxies ...*cloudsqlapi.AuthProxyWorkload) []*cloudsqlapi.AuthProxyWorkload {
+	for i := 0; i < len(proxies); i++ {
+		internal.MarkWorkloadNeedsUpdate(proxies[i], wl)
+	}
+	return proxies
+}
+
+func findContainer(workload *internal.DeploymentWorkload, name string) (corev1.Container, error) {
+	for _, container := range workload.Deployment.Spec.Template.Spec.Containers {
+		if container.Name == "csql-instance1" {
+			return container, nil
+		}
+	}
+	return corev1.Container{}, fmt.Errorf("no container found with name %s", name)
+}
+
+func findEnvVar(workload *internal.DeploymentWorkload, containerName string, envName string) (corev1.EnvVar, error) {
+	container, err := findContainer(workload, containerName)
+	if err != nil {
+		return corev1.EnvVar{}, err
+	}
+	for i := 0; i < len(container.Env); i++ {
+		if container.Env[i].Name == envName {
+			return container.Env[i], nil
+		}
+	}
+	return corev1.EnvVar{}, fmt.Errorf("no envvar named %v on container %v", envName, containerName)
+}
+
+func hasArg(workload *internal.DeploymentWorkload, containerName string, argValue string) (bool, error) {
+	container, err := findContainer(workload, containerName)
+	if err != nil {
+		return false, err
+	}
+	for i := 0; i < len(container.Command); i++ {
+		if container.Command[i] == argValue {
+			return true, nil
+		}
+	}
+	for i := 0; i < len(container.Args); i++ {
+		if container.Args[i] == argValue {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func logPodSpec(t *testing.T, wl *internal.DeploymentWorkload) {
+	podSpecYaml, err := yaml.Marshal(wl.Deployment.Spec.Template.Spec)
+	if err == nil {
+		t.Logf("PodSpec: %s", string(podSpecYaml))
+	}
+}
+
+func TestUpdateWorkload(t *testing.T) {
+	var (
+		wantsName                      = "instance1"
+		wantsPort                int32 = 8080
+		wantContainerName              = "csql-" + wantsName
+		wantsInstanceName              = "project:server:db"
+		wantsUpdatedInstanceName       = "project:server:newdb"
+		wantsInstanceArg               = fmt.Sprintf("%s?port=%d", wantsInstanceName, wantsPort)
+		wantsUpdatedInstanceArg        = fmt.Sprintf("%s?port=%d", wantsUpdatedInstanceName, wantsPort)
+	)
+
+	// Create a deployment
+	wl := makeWorkload()
+
+	// ensure that the new container does not exist
+	if len(wl.Deployment.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf("got %v, wants 1. deployment containers length", len(wl.Deployment.Spec.Template.Spec.Containers))
+	}
+
+	// Create a AuthProxyWorkload that matches the deployment
+	proxy := makeSimpleAuthProxy(wantsName, wantsInstanceName)
+	proxy.Spec.Instances[0].Port = &wantsPort
+	proxies := makeProxies(wl, proxy)
+
+	// Update the container with new proxies
+	internal.UpdateWorkloadContainers(wl, proxies)
+
+	// test that there are now 2 containers
+	if want, got := 2, len(wl.Deployment.Spec.Template.Spec.Containers); want != got {
+		t.Fatalf("got %v want %v, number of deployment containers", got, want)
+	}
+
+	t.Logf("Containers: {%v}", wl.Deployment.Spec.Template.Spec.Containers)
+
+	// test that the container has the proper name following the conventions
+	foundContainer, err := findContainer(wl, wantContainerName)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// test that the container args have the expected args
+	if gotArg, err := hasArg(wl, wantContainerName, wantsInstanceArg); err != nil || !gotArg {
+		t.Errorf("wants connection string arg %v but it was not present in proxy container args %v",
+			wantsInstanceArg, foundContainer.Args)
+	}
+
+	// Now change the spec
+	proxies[0].Spec.Instances[0].ConnectionString = wantsUpdatedInstanceName
+	proxies[0].ObjectMeta.Generation = 2
+	// update the containers again with the new instance name
+
+	// Indicate that the workload needs an update
+	internal.MarkWorkloadNeedsUpdate(proxies[0], wl)
+
+	// Perform the update
+	internal.UpdateWorkloadContainers(wl, proxies)
+
+	// test that there are now 2 containers
+	if want, got := 2, len(wl.Deployment.Spec.Template.Spec.Containers); want != got {
+		t.Fatalf("got %v want %v, number of deployment containers", got, want)
+	}
+
+	// test that the container has the proper name following the conventions
+	foundContainer, err = findContainer(wl, wantContainerName)
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// test that the container args have the expected args
+	if gotArg, err := hasArg(wl, wantContainerName, wantsUpdatedInstanceArg); err != nil || !gotArg {
+		t.Errorf("wants connection string arg %v but it was not present in proxy container args %v",
+			wantsInstanceArg, foundContainer.Args)
+	}
+
+	// now try with an empty workload list, which should remove the container
+	internal.UpdateWorkloadContainers(wl, []*cloudsqlapi.AuthProxyWorkload{})
+
+	// test that there is now only 1 conatiner
+	if len(wl.Deployment.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf("got %v, wants 1. deployment containers length", len(wl.Deployment.Spec.Template.Spec.Containers))
+	}
+
+}
+
+func TestUpdateWorkloadFixedPort(t *testing.T) {
+	var wantsInstanceName = "project:server:db"
+	var wantsPort = int32(5555)
+	var wantContainerArgs = []string{
+		fmt.Sprintf("%s?port=%d", wantsInstanceName, wantsPort),
+	}
+	var wantWorkloadEnv = map[string]string{
+		"DB_HOST": "localhost",
+		"DB_PORT": strconv.Itoa(int(wantsPort)),
+	}
+
+	// Create a deployment
+	wl := &internal.DeploymentWorkload{Deployment: &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "busybox", Labels: map[string]string{"app": "hello"}},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "busybox", Image: "busybox",
+						Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}}},
+				},
+			},
+		},
+	}}
+
+	// Create a AuthProxyWorkload that matches the deployment
+	csqls := []*cloudsqlapi.AuthProxyWorkload{&cloudsqlapi.AuthProxyWorkload{
+		TypeMeta:   metav1.TypeMeta{Kind: "AuthProxyWorkload", APIVersion: cloudsqlapi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: "instance1", Namespace: "default", Generation: 1},
+		Spec: cloudsqlapi.AuthProxyWorkloadSpec{
+			Workload: cloudsqlapi.WorkloadSelectorSpec{
+				Kind: "Deployment",
+				Selector: &metav1.LabelSelector{
+					MatchLabels:      map[string]string{"app": "hello"},
+					MatchExpressions: nil,
+				},
+			},
+			Instances: []cloudsqlapi.InstanceSpec{{
+				ConnectionString: wantsInstanceName,
+				Port:             &wantsPort,
+				PortEnvName:      "DB_PORT",
+				HostEnvName:      "DB_HOST",
+			}},
+		},
+		Status: cloudsqlapi.AuthProxyWorkloadStatus{},
+	}}
+
+	// ensure that the new container does not exist
+	if len(wl.Deployment.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf("got %v, wants 1. deployment containers length", len(wl.Deployment.Spec.Template.Spec.Containers))
+	}
+
+	// Indicate that the workload needs an update
+	internal.MarkWorkloadNeedsUpdate(csqls[0], wl)
+
+	// update the containers
+	internal.UpdateWorkloadContainers(wl, csqls)
+
+	// ensure that the new container does not exist
+	if len(wl.Deployment.Spec.Template.Spec.Containers) != 2 {
+		t.Fatalf("got %v, wants 1. deployment containers length", len(wl.Deployment.Spec.Template.Spec.Containers))
+	}
+
+	// test that the instancename matches the new expected instance name.
+	csqlContainer, err := findContainer(wl, fmt.Sprintf("csql-%s", csqls[0].GetName()))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// test that port cli args are set correctly
+	assertContainerArgsContains(t, csqlContainer.Args, wantContainerArgs)
+
+	// Test that workload has the right env vars
+	for wantKey, wantValue := range wantWorkloadEnv {
+		gotEnvVar, err := findEnvVar(wl, "busybox", wantKey)
+		if err != nil {
+			t.Errorf(err.Error())
+			logPodSpec(t, wl)
+		} else {
+			if gotEnvVar.Value != wantValue {
+				t.Errorf("got %v, wants %v workload env var %v", gotEnvVar, wantValue, wantKey)
+			}
+		}
+	}
+
+}
+
+func TestWorkloadNoPortSet(t *testing.T) {
+	var wantsInstanceName = "project:server:db"
+	var wantsPort = int32(5000)
+	var wantContainerArgs = []string{
+		fmt.Sprintf("%s?port=%d", wantsInstanceName, wantsPort),
+	}
+	var wantWorkloadEnv = map[string]string{
+		"DB_HOST": "localhost",
+		"DB_PORT": strconv.Itoa(int(wantsPort)),
+	}
+
+	// Create a deployment
+	wl := &internal.DeploymentWorkload{Deployment: &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "busybox", Labels: map[string]string{"app": "hello"}},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "busybox", Image: "busybox",
+						Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}}},
+				},
+			},
+		},
+	}}
+
+	// Create a AuthProxyWorkload that matches the deployment
+	csqls := []*cloudsqlapi.AuthProxyWorkload{&cloudsqlapi.AuthProxyWorkload{
+		TypeMeta:   metav1.TypeMeta{Kind: "AuthProxyWorkload", APIVersion: cloudsqlapi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: "instance1", Namespace: "default", Generation: 1},
+		Spec: cloudsqlapi.AuthProxyWorkloadSpec{
+			Workload: cloudsqlapi.WorkloadSelectorSpec{
+				Kind: "Deployment",
+				Selector: &metav1.LabelSelector{
+					MatchLabels:      map[string]string{"app": "hello"},
+					MatchExpressions: nil,
+				},
+			},
+			Instances: []cloudsqlapi.InstanceSpec{{
+				ConnectionString: wantsInstanceName,
+				PortEnvName:      "DB_PORT",
+				HostEnvName:      "DB_HOST",
+			}},
+		},
+		Status: cloudsqlapi.AuthProxyWorkloadStatus{},
+	}}
+
+	// ensure that the new container does not exist
+	if len(wl.Deployment.Spec.Template.Spec.Containers) != 1 {
+		t.Fatalf("got %v, wants 1. deployment containers length", len(wl.Deployment.Spec.Template.Spec.Containers))
+	}
+
+	// Indicate that the workload needs an update
+	internal.MarkWorkloadNeedsUpdate(csqls[0], wl)
+
+	// update the containers
+	internal.UpdateWorkloadContainers(wl, csqls)
+
+	// ensure that the new container does not exist
+	if len(wl.Deployment.Spec.Template.Spec.Containers) != 2 {
+		t.Fatalf("got %v, wants 1. deployment containers length", len(wl.Deployment.Spec.Template.Spec.Containers))
+	}
+
+	// test that the instancename matches the new expected instance name.
+	csqlContainer, err := findContainer(wl, fmt.Sprintf("csql-%s", csqls[0].GetName()))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// test that port cli args are set correctly
+	assertContainerArgsContains(t, csqlContainer.Args, wantContainerArgs)
+
+	// Test that workload has the right env vars
+	for wantKey, wantValue := range wantWorkloadEnv {
+		gotEnvVar, err := findEnvVar(wl, "busybox", wantKey)
+		if err != nil {
+			t.Errorf(err.Error())
+			logPodSpec(t, wl)
+		} else {
+			if gotEnvVar.Value != wantValue {
+				t.Errorf("got %v, wants %v workload env var %v", gotEnvVar, wantValue, wantKey)
+			}
+		}
+	}
+
+}
+
+func TestWorkloadUnixVolume(t *testing.T) {
+	var wantsInstanceName = "project:server:db"
+	var wantsUnixDir = "/mnt/db"
+	var wantContainerArgs = []string{
+		fmt.Sprintf("%s?unix-socket=%s", wantsInstanceName, wantsUnixDir),
+	}
+	var wantWorkloadEnv = map[string]string{
+		"DB_SOCKET_PATH": wantsUnixDir,
+	}
+
+	// Create a deployment
+	wl := &internal.DeploymentWorkload{Deployment: &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "busybox", Labels: map[string]string{"app": "hello"}},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "busybox", Image: "busybox",
+						Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}}},
+				},
+			},
+		},
+	}}
+
+	// Create a AuthProxyWorkload that matches the deployment
+	csqls := []*cloudsqlapi.AuthProxyWorkload{&cloudsqlapi.AuthProxyWorkload{
+		TypeMeta:   metav1.TypeMeta{Kind: "AuthProxyWorkload", APIVersion: cloudsqlapi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: "instance1", Namespace: "default", Generation: 1},
+		Spec: cloudsqlapi.AuthProxyWorkloadSpec{
+			Workload: cloudsqlapi.WorkloadSelectorSpec{
+				Kind: "Deployment",
+				Selector: &metav1.LabelSelector{
+					MatchLabels:      map[string]string{"app": "hello"},
+					MatchExpressions: nil,
+				},
+			},
+			Instances: []cloudsqlapi.InstanceSpec{{
+				ConnectionString:      wantsInstanceName,
+				UnixSocketPath:        wantsUnixDir,
+				UnixSocketPathEnvName: "DB_SOCKET_PATH",
+			}},
+		},
+		Status: cloudsqlapi.AuthProxyWorkloadStatus{},
+	}}
+
+	// Indicate that the workload needs an update
+	internal.MarkWorkloadNeedsUpdate(csqls[0], wl)
+
+	// update the containers
+	internal.UpdateWorkloadContainers(wl, csqls)
+
+	// ensure that the new container exists
+	if len(wl.Deployment.Spec.Template.Spec.Containers) != 2 {
+		t.Fatalf("got %v, wants 1. deployment containers length", len(wl.Deployment.Spec.Template.Spec.Containers))
+	}
+
+	// test that the instancename matches the new expected instance name.
+	csqlContainer, err := findContainer(wl, fmt.Sprintf("csql-%s", csqls[0].GetName()))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// test that port cli args are set correctly
+	assertContainerArgsContains(t, csqlContainer.Args, wantContainerArgs)
+
+	// Test that workload has the right env vars
+	for wantKey, wantValue := range wantWorkloadEnv {
+		gotEnvVar, err := findEnvVar(wl, "busybox", wantKey)
+		if err != nil {
+			t.Errorf(err.Error())
+			logPodSpec(t, wl)
+		} else {
+			if gotEnvVar.Value != wantValue {
+				t.Errorf("got %v, wants %v workload env var %v", gotEnvVar, wantValue, wantKey)
+			}
+		}
+	}
+
+	// test that volume exists
+	if want, got := 1, len(wl.Deployment.Spec.Template.Spec.Volumes); want != got {
+		t.Fatalf("got %v, wants %v. PodSpec.Volumes", got, want)
+	}
+
+	// test that volume mount exists on busybox
+	busyboxContainer, err := findContainer(wl, "busybox")
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+	if want, got := 1, len(busyboxContainer.VolumeMounts); want != got {
+		t.Fatalf("got %v, wants %v. Busybox Container.VolumeMounts", got, want)
+	}
+	if want, got := wantsUnixDir, busyboxContainer.VolumeMounts[0].MountPath; want != got {
+		t.Fatalf("got %v, wants %v. Busybox Container.VolumeMounts.MountPath", got, want)
+	}
+
+}
+
+func TestContainerImageChanged(t *testing.T) {
+	var wantsInstanceName = "project:server:db"
+	var wantImage = "custom-image:latest"
+
+	// Create a deployment
+	wl := &internal.DeploymentWorkload{Deployment: &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "busybox", Labels: map[string]string{"app": "hello"}},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "busybox", Image: "busybox",
+						Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}}},
+				},
+			},
+		},
+	}}
+
+	// Create a AuthProxyWorkload that matches the deployment
+	csqls := []*cloudsqlapi.AuthProxyWorkload{&cloudsqlapi.AuthProxyWorkload{
+		TypeMeta:   metav1.TypeMeta{Kind: "AuthProxyWorkload", APIVersion: cloudsqlapi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: "instance1", Namespace: "default", Generation: 1},
+		Spec: cloudsqlapi.AuthProxyWorkloadSpec{
+			Workload: cloudsqlapi.WorkloadSelectorSpec{
+				Kind: "Deployment",
+				Selector: &metav1.LabelSelector{
+					MatchLabels:      map[string]string{"app": "hello"},
+					MatchExpressions: nil,
+				},
+			},
+			ProxyContainer: &cloudsqlapi.ProxyContainerSpec{Image: wantImage},
+			Instances: []cloudsqlapi.InstanceSpec{{
+				ConnectionString: wantsInstanceName,
+			}},
+		},
+		Status: cloudsqlapi.AuthProxyWorkloadStatus{},
+	}}
+
+	// Indicate that the workload needs an update
+	internal.MarkWorkloadNeedsUpdate(csqls[0], wl)
+
+	// update the containers
+	internal.UpdateWorkloadContainers(wl, csqls)
+
+	// ensure that the new container exists
+	if len(wl.Deployment.Spec.Template.Spec.Containers) != 2 {
+		t.Fatalf("got %v, wants 1. deployment containers length", len(wl.Deployment.Spec.Template.Spec.Containers))
+	}
+
+	// test that the instancename matches the new expected instance name.
+	csqlContainer, err := findContainer(wl, fmt.Sprintf("csql-%s", csqls[0].GetName()))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// test that image was set
+	if csqlContainer.Image != wantImage {
+		t.Errorf("got %v, want %v for proxy container image", csqlContainer.Image, wantImage)
+	}
+
+}
+
+func TestContainerReplaced(t *testing.T) {
+	var wantsInstanceName = "project:server:db"
+	var wantContainer = &corev1.Container{
+		Name: "sample", Image: "debian:latest", Command: []string{"/bin/bash"},
+	}
+
+	// Create a deployment
+	wl := &internal.DeploymentWorkload{Deployment: &appsv1.Deployment{
+		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "busybox", Labels: map[string]string{"app": "hello"}},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{Name: "busybox", Image: "busybox",
+						Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}}},
+				},
+			},
+		},
+	}}
+
+	// Create a AuthProxyWorkload that matches the deployment
+	csqls := []*cloudsqlapi.AuthProxyWorkload{&cloudsqlapi.AuthProxyWorkload{
+		TypeMeta:   metav1.TypeMeta{Kind: "AuthProxyWorkload", APIVersion: cloudsqlapi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: "instance1", Namespace: "default", Generation: 1},
+		Spec: cloudsqlapi.AuthProxyWorkloadSpec{
+			Workload: cloudsqlapi.WorkloadSelectorSpec{
+				Kind: "Deployment",
+				Selector: &metav1.LabelSelector{
+					MatchLabels:      map[string]string{"app": "hello"},
+					MatchExpressions: nil,
+				},
+			},
+			ProxyContainer: &cloudsqlapi.ProxyContainerSpec{Container: wantContainer},
+			Instances: []cloudsqlapi.InstanceSpec{{
+				ConnectionString: wantsInstanceName,
+			}},
+		},
+		Status: cloudsqlapi.AuthProxyWorkloadStatus{},
+	}}
+
+	// Indicate that the workload needs an update
+	internal.MarkWorkloadNeedsUpdate(csqls[0], wl)
+
+	// update the containers
+	internal.UpdateWorkloadContainers(wl, csqls)
+
+	// ensure that the new container exists
+	if len(wl.Deployment.Spec.Template.Spec.Containers) != 2 {
+		t.Fatalf("got %v, wants 1. deployment containers length", len(wl.Deployment.Spec.Template.Spec.Containers))
+	}
+
+	// test that the instancename matches the new expected instance name.
+	csqlContainer, err := findContainer(wl, fmt.Sprintf("csql-%s", csqls[0].GetName()))
+	if err != nil {
+		t.Fatalf(err.Error())
+	}
+
+	// test that image was set
+	if csqlContainer.Image != wantContainer.Image {
+		t.Errorf("got %v, want %v for proxy container image", csqlContainer.Image, wantContainer.Image)
+	}
+	// test that image was set
+	if !reflect.DeepEqual(csqlContainer.Command, wantContainer.Command) {
+		t.Errorf("got %v, want %v for proxy container command", csqlContainer.Command, wantContainer.Command)
+	}
+
+}
+
+func basicProxy(spec cloudsqlapi.AuthProxyWorkloadSpec) *cloudsqlapi.AuthProxyWorkload {
+	proxy := &cloudsqlapi.AuthProxyWorkload{
+		TypeMeta:   metav1.TypeMeta{Kind: "AuthProxyWorkload", APIVersion: cloudsqlapi.GroupVersion.String()},
+		ObjectMeta: metav1.ObjectMeta{Name: "instance1", Namespace: "default", Generation: 1},
+		Spec:       spec,
+		Status:     cloudsqlapi.AuthProxyWorkloadStatus{},
+	}
+	proxy.Spec.Workload = cloudsqlapi.WorkloadSelectorSpec{
+		Kind: "Deployment",
+		Selector: &metav1.LabelSelector{
+			MatchLabels:      map[string]string{"app": "hello"},
+			MatchExpressions: nil,
+		},
+	}
+
+	return proxy
+}
+
+func ptr[T int | int32 | string](i T) *T {
+	return &i
+}
+
+func TestProxyCLIArgs(t *testing.T) {
+	type testParam struct {
+		desc                 string
+		wantsInstanceName    string
+		proxySpec            cloudsqlapi.AuthProxyWorkloadSpec
+		wantProxyArgContains []string
+		wantErrorCodes       []string
+	}
+	wantTrue := true
+	wantFalse := false
+
+	var wantPort int32 = 5000
+
+	var testcases = []testParam{
+		{
+			desc: "default cli config",
+			proxySpec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "hello:world:db",
+					Port:             &wantPort,
+					PortEnvName:      "DB_PORT",
+				}},
+			},
+			wantProxyArgContains: []string{
+				"--structured-logs",
+				"--health-check",
+				fmt.Sprintf("--http-port=%d", internal.DefaultHealthCheckPort),
+			},
+		},
+		{
+			desc: "port explicitly set",
+			proxySpec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "hello:world:db",
+					Port:             &wantPort,
+					PortEnvName:      "DB_PORT",
+				}},
+			},
+			wantProxyArgContains: []string{"hello:world:db?port=5000"},
+		},
+		{
+			desc: "fuse not supported error",
+			proxySpec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString:      "hello:world:db",
+					FusePath:              "/fuse/db",
+					FuseVolumePathEnvName: "FUSE_PATH",
+				}},
+			},
+			wantProxyArgContains: []string{"hello:world:db?port=5000"},
+			wantErrorCodes:       []string{internal.ErrorCodeFUSENotSupported},
+		},
+		{
+			desc: "port implicitly set and increments",
+			proxySpec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "hello:world:one",
+					PortEnvName:      "DB_PORT",
+				},
+					{
+						ConnectionString: "hello:world:two",
+						PortEnvName:      "DB_PORT_2",
+					}},
+			},
+			wantProxyArgContains: []string{
+				fmt.Sprintf("hello:world:one?port=%d", internal.DefaultFirstPort),
+				fmt.Sprintf("hello:world:two?port=%d", internal.DefaultFirstPort+1)},
+		},
+		{
+			desc: "env name conflict causes error",
+			proxySpec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "hello:world:one",
+					PortEnvName:      "DB_PORT",
+				},
+					{
+						ConnectionString: "hello:world:two",
+						PortEnvName:      "DB_PORT",
+					}},
+			},
+			wantProxyArgContains: []string{
+				fmt.Sprintf("hello:world:one?port=%d", internal.DefaultFirstPort),
+				fmt.Sprintf("hello:world:two?port=%d", internal.DefaultFirstPort+1)},
+			wantErrorCodes: []string{internal.ErrorCodeEnvConflict},
+		},
+		{
+			desc: "auto-iam-authn set",
+			proxySpec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "hello:world:one",
+					PortEnvName:      "DB_PORT",
+					AutoIamAuthn:     &wantTrue,
+				},
+					{
+						ConnectionString: "hello:world:two",
+						PortEnvName:      "DB_PORT_2",
+						AutoIamAuthn:     &wantFalse,
+					}},
+			},
+			wantProxyArgContains: []string{
+				fmt.Sprintf("hello:world:one?auto-iam-authn=true&port=%d", internal.DefaultFirstPort),
+				fmt.Sprintf("hello:world:two?auto-iam-authn=false&port=%d", internal.DefaultFirstPort+1)},
+		},
+		{
+			desc: "private-ip set",
+			proxySpec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "hello:world:one",
+					PortEnvName:      "DB_PORT",
+					PrivateIp:        &wantTrue,
+				},
+					{
+						ConnectionString: "hello:world:two",
+						PortEnvName:      "DB_PORT_2",
+						PrivateIp:        &wantFalse,
+					}},
+			},
+			wantProxyArgContains: []string{
+				fmt.Sprintf("hello:world:one?port=%d&private-ip=true", internal.DefaultFirstPort),
+				fmt.Sprintf("hello:world:two?port=%d&private-ip=false", internal.DefaultFirstPort+1)},
+		},
+		{
+			desc: "telemetry flags",
+			proxySpec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{},
+				ProxyContainer: &cloudsqlapi.ProxyContainerSpec{
+					SQLAdminApiEndpoint: "https://example.com",
+					Telemetry: &cloudsqlapi.TelemetrySpec{
+						PrometheusNamespace: ptr("hello"),
+						TelemetryPrefix:     ptr("telprefix"),
+						TelemetryProject:    ptr("telproject"),
+						TelemetrySampleRate: ptr(200),
+						HttpPort:            ptr(int32(9091)),
+						DisableTraces:       &wantTrue,
+						DisableMetrics:      &wantTrue,
+						Prometheus:          &wantTrue,
+					},
+				},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "hello:world:one",
+				}},
+			},
+			wantProxyArgContains: []string{
+				fmt.Sprintf("hello:world:one?port=%d", internal.DefaultFirstPort),
+				"--sqladmin-api-endpoint=https://example.com",
+				"--telemetry-sample-rate=200",
+				"--prometheus-namespace=hello",
+				"--telemetry-project=telproject",
+				"--telemetry-prefix=telprefix",
+				"--http-port=9091",
+				"--health-check",
+				"--disable-traces",
+				"--disable-metrics",
+				"--prometheus",
+			},
+		},
+		{
+			desc: "port conflict with other instance causes error",
+			proxySpec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "hello:world:one",
+					PortEnvName:      "DB_PORT_1",
+					Port:             ptr(int32(8081)),
+				},
+					{
+						ConnectionString: "hello:world:two",
+						PortEnvName:      "DB_PORT_2",
+						Port:             ptr(int32(8081)),
+					}},
+			},
+			wantProxyArgContains: []string{
+				fmt.Sprintf("hello:world:one?port=%d", 8081),
+				fmt.Sprintf("hello:world:two?port=%d", 8081)},
+			wantErrorCodes: []string{internal.ErrorCodePortConflict},
+		},
+		{
+			desc: "port conflict with workload container",
+			proxySpec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "hello:world:one",
+					PortEnvName:      "DB_PORT_1",
+					Port:             ptr(int32(8080)),
+				}},
+			},
+			wantProxyArgContains: []string{
+				fmt.Sprintf("hello:world:one?port=%d", 8080)},
+			wantErrorCodes: []string{internal.ErrorCodePortConflict},
+		},
+	}
+
+	t.Parallel()
+	for i := 0; i < len(testcases); i++ {
+		tc := &testcases[i]
+		t.Run(tc.desc, func(t *testing.T) {
+
+			// Create a deployment
+			wl := &internal.DeploymentWorkload{Deployment: &appsv1.Deployment{
+				TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "busybox", Labels: map[string]string{"app": "hello"}},
+				Spec: appsv1.DeploymentSpec{
+					Template: corev1.PodTemplateSpec{
+						Spec: corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "busybox", Image: "busybox",
+								Ports: []corev1.ContainerPort{{Name: "http", ContainerPort: 8080}}}},
+						},
+					},
+				},
+			}}
+
+			// Create a AuthProxyWorkload that matches the deployment
+			csqls := []*cloudsqlapi.AuthProxyWorkload{basicProxy(tc.proxySpec)}
+
+			// Indicate that the workload needs an update
+			internal.MarkWorkloadNeedsUpdate(csqls[0], wl)
+
+			// update the containers
+			_, updateErr := internal.UpdateWorkloadContainers(wl, csqls)
+
+			// ensure that the new container exists
+			if len(wl.Deployment.Spec.Template.Spec.Containers) != 2 {
+				t.Fatalf("got %v, wants 1. deployment containers length", len(wl.Deployment.Spec.Template.Spec.Containers))
+			}
+
+			// test that the instancename matches the new expected instance name.
+			csqlContainer, err := findContainer(wl, fmt.Sprintf("csql-%s", csqls[0].GetName()))
+			if err != nil {
+				t.Fatalf(err.Error())
+			}
+
+			// test that port cli args are set correctly
+			assertContainerArgsContains(t, csqlContainer.Args, tc.wantProxyArgContains)
+			assertErrorCodeContains(t, updateErr, tc.wantErrorCodes)
+
+		})
+	}
+
+}
+
+func assertErrorCodeContains(t *testing.T, gotError *internal.ConfigError, wantErrors []string) {
+	if gotError == nil {
+		if len(wantErrors) > 0 {
+			t.Errorf("got missing errors, wants errors with codes %v", wantErrors)
+		}
+		return
+	}
+
+	errs := gotError.DetailedErrors()
+
+	for i := 0; i < len(wantErrors); i++ {
+		wantArg := wantErrors[i]
+		found := false
+		for j := 0; j < len(errs) && !found; j++ {
+			if wantArg == errs[j].ErrorCode {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing error, wants error with code %v, got error %v", wantArg, gotError)
+		}
+	}
+
+	for i := 0; i < len(errs); i++ {
+		gotErr := errs[i]
+		found := false
+		for j := 0; j < len(wantErrors) && !found; j++ {
+			if gotErr.ErrorCode == wantErrors[j] {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("got unexpected error %v", gotErr)
+		}
+	}
+
+}
+
+func assertContainerArgsContains(t *testing.T, gotArgs []string, wantArgs []string) {
+	for i := 0; i < len(wantArgs); i++ {
+		wantArg := wantArgs[i]
+		found := false
+		for j := 0; j < len(gotArgs) && !found; j++ {
+			if wantArg == gotArgs[j] {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing argument, wants argument %v, got arguments %v", wantArg, gotArgs)
+		}
+	}
+}

--- a/internal/updatestate_test.go
+++ b/internal/updatestate_test.go
@@ -1,0 +1,80 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"reflect"
+	"testing"
+)
+
+type data struct {
+	name  string
+	value string
+}
+
+var one = data{
+	name:  "one",
+	value: "one",
+}
+var two = data{
+	name:  "two",
+	value: "two",
+}
+var twoB = data{
+	name:  "two",
+	value: "b",
+}
+var three = data{
+	name:  "three",
+	value: "three",
+}
+
+func isNameEqual(a *data, b *data) bool {
+	return a.name == b.name
+}
+
+func TestAppendOrReplace(t *testing.T) {
+
+	// replace
+	if want, got :=
+		[]data{one, twoB},
+		appendOrReplace([]data{one, two}, twoB, isNameEqual); !reflect.DeepEqual(want, got) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// append
+	if want, got :=
+		[]data{one, two, three},
+		appendOrReplace([]data{one, two}, three, isNameEqual); !reflect.DeepEqual(want, got) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// empty
+	if want, got :=
+		[]data{one},
+		appendOrReplace([]data{}, one, isNameEqual); !reflect.DeepEqual(want, got) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+	// nil
+	var d []data
+	d = nil
+	if want, got :=
+		[]data{one},
+		appendOrReplace(d, one, isNameEqual); !reflect.DeepEqual(want, got) {
+		t.Errorf("got %v, want %v", got, want)
+	}
+
+}

--- a/internal/workload.go
+++ b/internal/workload.go
@@ -1,0 +1,317 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"fmt"
+
+	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/api/v1alpha1"
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/names"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	logf "sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+const DefaultContainerImage = "us-central1-docker.pkg.dev/csql-operator-test/test76e6d646e2caac1c458c/proxy-v2:latest" //TODO get the right name here.
+var defaultContainerResources = corev1.ResourceRequirements{
+	Requests: corev1.ResourceList{
+		"cpu":    resource.MustParse("1.0"),
+		"memory": resource.MustParse("1Gi"),
+	},
+}
+
+var (
+	l = logf.Log.WithName("internal.workload")
+)
+
+// ReconcileWorkload finds all AuthProxyWorkload resources matching this workload and then
+// updates the workload's containers. This does not save the updated workload.
+func ReconcileWorkload(instList cloudsqlapi.AuthProxyWorkloadList, workload Workload) (bool, []*cloudsqlapi.AuthProxyWorkload, *ConfigError) {
+	// if a workload has an owner, then ignore it.
+	if len(workload.GetObject().GetOwnerReferences()) > 0 {
+		return false, []*cloudsqlapi.AuthProxyWorkload{}, nil
+	}
+
+	matchingAuthProxyWorkloads := FilterMatchingInstances(instList, workload)
+	updated, err := UpdateWorkloadContainers(workload, matchingAuthProxyWorkloads)
+	if updated {
+		return true, matchingAuthProxyWorkloads, err
+	} else {
+		return false, []*cloudsqlapi.AuthProxyWorkload{}, nil
+	}
+
+}
+
+// FilterMatchingInstances returns a list of AuthProxyWorkload whose selectors match
+// the workload.
+func FilterMatchingInstances(wlList cloudsqlapi.AuthProxyWorkloadList, workload Workload) []*cloudsqlapi.AuthProxyWorkload {
+	matchingAuthProxyWorkloads := make([]*cloudsqlapi.AuthProxyWorkload, 0, len(wlList.Items))
+	for i, _ := range wlList.Items {
+		csqlWorkload := &wlList.Items[i]
+		if WorkloadMatches(workload, csqlWorkload.Spec.Workload, csqlWorkload.Namespace) {
+			// need to update workload
+			l.Info("Found matching workload", "workload", workload.GetObject().GetNamespace()+"/"+workload.GetObject().GetName(), "wlSelector", csqlWorkload.Spec.Workload, "AuthProxyWorkload", csqlWorkload.Namespace+"/"+csqlWorkload.Name)
+			matchingAuthProxyWorkloads = append(matchingAuthProxyWorkloads, csqlWorkload)
+		}
+	}
+	return matchingAuthProxyWorkloads
+}
+
+// WorkloadMatches tests if a workload matches a modifier based on its name, kind, and selectors
+func WorkloadMatches(wl Workload, workloadSelector cloudsqlapi.WorkloadSelectorSpec, ns string) bool {
+	if workloadSelector.Kind != "" && wl.GetObject().GetObjectKind().GroupVersionKind().Kind != workloadSelector.Kind {
+		return false
+	}
+	if workloadSelector.Name != "" && wl.GetObject().GetName() != workloadSelector.Name {
+		return false
+	}
+	if ns != "" && wl.GetObject().GetNamespace() != ns {
+		return false
+	}
+
+	sel, err := workloadSelector.LabelsSelector()
+	if err != nil {
+		return false
+	}
+	if !sel.Empty() && !sel.Matches(labels.Set(wl.GetObject().GetLabels())) {
+		return false
+	}
+
+	return true
+}
+
+type WorkloadUpdateStatus struct {
+	InstanceGeneration    string
+	LastRequstGeneration  string
+	RequestGeneration     string
+	LastUpdatedGeneration string
+	UpdatedGeneration     string
+}
+
+// MarkWorkloadNeedsUpdate Updates annotations on the workload indicating that it may need an update.
+// returns true if the workload actually needs an update.
+func MarkWorkloadNeedsUpdate(csqlWorkload *cloudsqlapi.AuthProxyWorkload, workload Workload) (bool, WorkloadUpdateStatus) {
+	return updateWorkloadAnnotations(csqlWorkload, workload, false)
+}
+
+// MarkWorkloadUpdated Updates annotations on the workload indicating that it
+// has been updated, returns true of any modifications were made to the workload.
+// for the AuthProxyWorkload.
+func MarkWorkloadUpdated(csqlWorkload *cloudsqlapi.AuthProxyWorkload, workload Workload) (bool, WorkloadUpdateStatus) {
+	return updateWorkloadAnnotations(csqlWorkload, workload, true)
+}
+
+// updateWorkloadAnnotations adds annotations to the workload
+// to track which generation of a AuthProxyWorkload needs to be applied, and which
+// generation has been applied. The AuthProxyWorkload controller is responsible for
+// tracking which version should be applied, The workload admission webhook is
+// responsible for applying the AuthProxyWorkloads that apply to a workload
+// when the workload is created or modified.
+func updateWorkloadAnnotations(csqlWorkload *cloudsqlapi.AuthProxyWorkload, workload Workload, doingUpdate bool) (bool, WorkloadUpdateStatus) {
+	s := WorkloadUpdateStatus{}
+	doUpdate := false
+	reqName := names.SafePrefixedName("csqlr-", csqlWorkload.Name)
+	resultName := names.SafePrefixedName("csqlu-", csqlWorkload.Name)
+	s.InstanceGeneration = fmt.Sprintf("%d", csqlWorkload.GetGeneration())
+
+	ann := workload.GetObject().GetAnnotations()
+	if ann == nil {
+		ann = map[string]string{}
+	}
+	s.LastRequstGeneration = ann[reqName]
+	s.LastUpdatedGeneration = ann[resultName]
+
+	if s.LastRequstGeneration != s.InstanceGeneration {
+		ann[reqName] = s.InstanceGeneration
+		if doingUpdate {
+			ann[resultName] = s.InstanceGeneration
+		}
+		doUpdate = true
+	}
+	if s.LastUpdatedGeneration != s.InstanceGeneration {
+		if doingUpdate {
+			ann[resultName] = s.InstanceGeneration
+		}
+		doUpdate = true
+	}
+	workload.GetObject().SetAnnotations(ann)
+	s.RequestGeneration = ann[reqName]
+	s.UpdatedGeneration = ann[resultName]
+
+	return doUpdate, s
+}
+
+// Workload interface a standard way to access the pod definition for the
+// 5 major kinds of interfaces: Deployment, Pod, StatefulSet, Job, and Cronjob.
+// These methods are used by the ModifierStore to update the contents of the
+// workload's pod template (or the pod itself) so that it will contain
+// necessary configuration and other details before it starts, or if the
+// configuration changes.
+type Workload interface {
+	GetPodSpec() corev1.PodSpec
+	SetPodSpec(spec corev1.PodSpec)
+	GetPodObjectMeta() metav1.ObjectMeta
+	SetPodObjectMeta(meta metav1.ObjectMeta)
+	GetObject() client.Object
+}
+
+func WorkloadKey(wl Workload) string {
+	return wl.GetObject().GetObjectKind().GroupVersionKind().String() + "/" + client.ObjectKeyFromObject(wl.GetObject()).String()
+}
+
+// A workload for deployments, returning the pod template spec
+type DeploymentWorkload struct {
+	Deployment *appsv1.Deployment
+}
+
+func (d *DeploymentWorkload) GetPodSpec() corev1.PodSpec {
+	return d.Deployment.Spec.Template.Spec
+}
+
+func (d *DeploymentWorkload) SetPodSpec(spec corev1.PodSpec) {
+	d.Deployment.Spec.Template.Spec = spec
+}
+
+func (d *DeploymentWorkload) GetPodObjectMeta() metav1.ObjectMeta {
+	return d.Deployment.Spec.Template.ObjectMeta
+}
+
+func (d *DeploymentWorkload) SetPodObjectMeta(meta metav1.ObjectMeta) {
+	d.Deployment.Spec.Template.ObjectMeta = meta
+}
+
+func (d *DeploymentWorkload) GetObject() client.Object {
+	return d.Deployment
+}
+
+type StatefulSetWorkload struct {
+	StatefulSet *appsv1.StatefulSet
+}
+
+func (d *StatefulSetWorkload) GetPodSpec() corev1.PodSpec {
+	return d.StatefulSet.Spec.Template.Spec
+}
+
+func (d *StatefulSetWorkload) SetPodSpec(spec corev1.PodSpec) {
+	d.StatefulSet.Spec.Template.Spec = spec
+}
+
+func (d *StatefulSetWorkload) GetPodObjectMeta() metav1.ObjectMeta {
+	return d.StatefulSet.Spec.Template.ObjectMeta
+}
+
+func (d *StatefulSetWorkload) SetPodObjectMeta(meta metav1.ObjectMeta) {
+	d.StatefulSet.Spec.Template.ObjectMeta = meta
+}
+func (d *StatefulSetWorkload) GetObject() client.Object {
+	return d.StatefulSet
+}
+
+type PodWorkload struct {
+	Pod *corev1.Pod
+}
+
+func (d *PodWorkload) GetPodSpec() corev1.PodSpec {
+	return d.Pod.Spec
+}
+
+func (d *PodWorkload) SetPodSpec(spec corev1.PodSpec) {
+	d.Pod.Spec = spec
+}
+
+func (d *PodWorkload) GetPodObjectMeta() metav1.ObjectMeta {
+	return d.Pod.ObjectMeta
+}
+
+func (d *PodWorkload) SetPodObjectMeta(meta metav1.ObjectMeta) {
+	d.Pod.ObjectMeta = meta
+}
+func (d *PodWorkload) GetObject() client.Object {
+	return d.Pod
+}
+
+type JobWorkload struct {
+	Job *batchv1.Job
+}
+
+func (d *JobWorkload) GetPodSpec() corev1.PodSpec {
+	return d.Job.Spec.Template.Spec
+}
+
+func (d *JobWorkload) SetPodSpec(spec corev1.PodSpec) {
+	d.Job.Spec.Template.Spec = spec
+}
+
+func (d *JobWorkload) GetPodObjectMeta() metav1.ObjectMeta {
+	return d.Job.Spec.Template.ObjectMeta
+}
+
+func (d *JobWorkload) SetPodObjectMeta(meta metav1.ObjectMeta) {
+	d.Job.Spec.Template.ObjectMeta = meta
+}
+func (d *JobWorkload) GetObject() client.Object {
+	return d.Job
+}
+
+type CronJobWorkload struct {
+	CronJob *batchv1.CronJob
+}
+
+func (d *CronJobWorkload) GetPodSpec() corev1.PodSpec {
+	return d.CronJob.Spec.JobTemplate.Spec.Template.Spec
+}
+
+func (d *CronJobWorkload) SetPodSpec(spec corev1.PodSpec) {
+	d.CronJob.Spec.JobTemplate.Spec.Template.Spec = spec
+}
+
+func (d *CronJobWorkload) GetPodObjectMeta() metav1.ObjectMeta {
+	return d.CronJob.Spec.JobTemplate.Spec.Template.ObjectMeta
+}
+
+func (d *CronJobWorkload) SetPodObjectMeta(meta metav1.ObjectMeta) {
+	d.CronJob.Spec.JobTemplate.Spec.Template.ObjectMeta = meta
+}
+func (d *CronJobWorkload) GetObject() client.Object {
+	return d.CronJob
+}
+
+type DaemonSetWorkload struct {
+	DaemonSet *appsv1.DaemonSet
+}
+
+func (d *DaemonSetWorkload) GetPodSpec() corev1.PodSpec {
+	return d.DaemonSet.Spec.Template.Spec
+}
+
+func (d *DaemonSetWorkload) SetPodSpec(spec corev1.PodSpec) {
+	d.DaemonSet.Spec.Template.Spec = spec
+}
+
+func (d *DaemonSetWorkload) GetPodObjectMeta() metav1.ObjectMeta {
+	return d.DaemonSet.Spec.Template.ObjectMeta
+}
+
+func (d *DaemonSetWorkload) SetPodObjectMeta(meta metav1.ObjectMeta) {
+	d.DaemonSet.Spec.Template.ObjectMeta = meta
+}
+func (d *DaemonSetWorkload) GetObject() client.Object {
+	return d.DaemonSet
+}

--- a/internal/workload_test.go
+++ b/internal/workload_test.go
@@ -1,0 +1,242 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"log"
+	"testing"
+
+	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/api/v1alpha1"
+	appsv1 "k8s.io/api/apps/v1"
+	batchv1 "k8s.io/api/batch/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestWorkloadMatches(t *testing.T) {
+	type workloadTestCase struct {
+		wl    Workload
+		match bool
+		desc  string
+	}
+
+	type testcases struct {
+		desc string
+		sel  cloudsqlapi.WorkloadSelectorSpec
+		tc   []workloadTestCase
+	}
+	cases := []testcases{{
+		desc: "match kind, name, and namespace",
+		sel: cloudsqlapi.WorkloadSelectorSpec{
+			Kind:     "Pod",
+			Name:     "hello",
+			Selector: nil,
+		},
+		tc: []workloadTestCase{
+			{
+				wl:    mustMakeWorkload("Pod", "default", "hello"),
+				match: true,
+				desc:  "matching pod",
+			},
+			{
+				wl:    mustMakeWorkload("Pod", "default", "hello", "app", "pod"),
+				match: true,
+				desc:  "matching pod with extra label",
+			},
+			{
+				wl:    mustMakeWorkload("Pod", "default", "pod", "app", "pod"),
+				match: false,
+				desc:  "pod with different name",
+			},
+			{
+				wl:    mustMakeWorkload("Pod", "other", "hello"),
+				match: false,
+				desc:  "pod with different namespace",
+			},
+			{
+				wl:    mustMakeWorkload("Deployment", "default", "hello"),
+				match: false,
+				desc:  "different kind",
+			},
+		},
+	},
+		{
+			desc: "match kind, namespace, and labels",
+			sel: cloudsqlapi.WorkloadSelectorSpec{
+				Kind: "Pod",
+				Name: "",
+				Selector: &metav1.LabelSelector{
+					MatchLabels:      map[string]string{"app": "hello"},
+					MatchExpressions: nil,
+				},
+			},
+			tc: []workloadTestCase{
+				{
+					wl:    mustMakeWorkload("Pod", "default", "hello"),
+					match: false,
+					desc:  "label not set",
+				},
+				{
+					wl:    mustMakeWorkload("Pod", "default", "hello", "app", "hello", "type", "frontend"),
+					match: true,
+					desc:  "matching pod with extra label",
+				},
+				{
+					wl:    mustMakeWorkload("Pod", "default", "pod", "app", "nope"),
+					match: false,
+					desc:  "pod with different label",
+				},
+				{
+					wl:    mustMakeWorkload("Pod", "Other", "hello", "app", "hello", "type", "frontend"),
+					match: false,
+					desc:  "pod with different namespace",
+				},
+				{
+					wl:    mustMakeWorkload("Deployment", "default", "hello", "app", "hello", "type", "frontend"),
+					match: false,
+					desc:  "Deploymnet with different namespace",
+				},
+			},
+		},
+		{
+			desc: "match namespace, and labels",
+			sel: cloudsqlapi.WorkloadSelectorSpec{
+				Kind: "",
+				Name: "",
+				Selector: &metav1.LabelSelector{
+					MatchLabels:      map[string]string{"app": "hello"},
+					MatchExpressions: nil,
+				},
+			},
+			tc: []workloadTestCase{
+				{
+					wl:    mustMakeWorkload("Pod", "default", "hello", "app", "hello", "type", "frontend"),
+					match: true,
+					desc:  "matching pod with extra label",
+				},
+				{
+					wl:    mustMakeWorkload("Pod", "default", "pod", "app", "nope"),
+					match: false,
+					desc:  "pod with different label",
+				},
+				{
+					wl:    mustMakeWorkload("Deployment", "default", "hello", "app", "hello", "type", "frontend"),
+					match: true,
+					desc:  "deployment with extra label",
+				},
+				{
+					wl:    mustMakeWorkload("Deployment", "default", "pod", "app", "nope"),
+					match: false,
+					desc:  "deployment with different label",
+				},
+				{
+					wl:    mustMakeWorkload("StatefulSet", "default", "things"),
+					match: false,
+					desc:  "StatefulSet no labels",
+				},
+			},
+		},
+		{
+			desc: "match namespace, and label expression",
+			sel: cloudsqlapi.WorkloadSelectorSpec{
+				Kind: "",
+				Name: "",
+				Selector: &metav1.LabelSelector{
+					MatchLabels: nil,
+					MatchExpressions: []metav1.LabelSelectorRequirement{{
+						Key:      "app",
+						Operator: metav1.LabelSelectorOpIn,
+						Values:   []string{"hello"},
+					}},
+				},
+			},
+			tc: []workloadTestCase{
+				{
+					wl:    mustMakeWorkload("Pod", "default", "hello", "app", "hello", "type", "frontend"),
+					match: true,
+					desc:  "matching pod with extra label",
+				},
+				{
+					wl:    mustMakeWorkload("Pod", "other", "hello", "app", "hello", "type", "frontend"),
+					match: false,
+					desc:  "pod with matching label, different namespace",
+				},
+				{
+					wl:    mustMakeWorkload("Pod", "default", "pod", "app", "nope"),
+					match: false,
+					desc:  "pod with different label",
+				},
+				{
+					wl:    mustMakeWorkload("Deployment", "default", "hello", "app", "hello", "type", "frontend"),
+					match: true,
+					desc:  "deployment with extra label",
+				},
+				{
+					wl:    mustMakeWorkload("Deployment", "default", "pod", "app", "nope"),
+					match: false,
+					desc:  "deployment with different label",
+				},
+			},
+		},
+	}
+
+	t.Parallel()
+	for _, sel := range cases {
+		for _, tc := range sel.tc {
+			t.Run(sel.desc+" "+tc.desc, func(t *testing.T) {
+				gotMatch := WorkloadMatches(tc.wl, sel.sel, "default")
+				if tc.match != gotMatch {
+					t.Errorf("got %v, wants %v. selector %s test %s", gotMatch, tc.match, sel.desc, tc.desc)
+				}
+			})
+		}
+	}
+
+}
+
+// mustMakeWorkload is shorthand to create workload test inputs
+func mustMakeWorkload(kind string, ns string, name string, l ...string) Workload {
+	var v Workload
+	switch kind {
+	case "Deployment":
+		v = &DeploymentWorkload{Deployment: &appsv1.Deployment{TypeMeta: metav1.TypeMeta{Kind: "Deployment"}}}
+	case "Pod":
+		v = &PodWorkload{Pod: &corev1.Pod{TypeMeta: metav1.TypeMeta{Kind: "Pod"}}}
+	case "StatefulSet":
+		v = &StatefulSetWorkload{StatefulSet: &appsv1.StatefulSet{TypeMeta: metav1.TypeMeta{Kind: "StatefulSet"}}}
+	case "Job":
+		v = &JobWorkload{Job: &batchv1.Job{TypeMeta: metav1.TypeMeta{Kind: "Job"}}}
+	case "CronJob":
+		v = &CronJobWorkload{CronJob: &batchv1.CronJob{TypeMeta: metav1.TypeMeta{Kind: "CronJob"}}}
+	case "DaemonSet":
+		v = &DaemonSetWorkload{DaemonSet: &appsv1.DaemonSet{TypeMeta: metav1.TypeMeta{Kind: "DaemonSet"}}}
+	default:
+		log.Fatalf("Workload kind %s not supported", kind)
+	}
+	v.GetObject().SetNamespace(ns)
+	v.GetObject().SetName(name)
+	if len(l) > 0 {
+		if len(l)%2 != 0 {
+			log.Fatalf("labels list must have an even number of elements")
+		}
+		labels := map[string]string{}
+		for i := 0; i < len(l); i += 2 {
+			labels[l[i]] = l[i+1]
+		}
+		v.GetObject().SetLabels(labels)
+	}
+
+	return v
+}


### PR DESCRIPTION
This PR includes the logic and tests to make sure that the AuthProxyWorkload is correctly applied to kubernetes
workloads. The AuthProxyWorkload specifies one or more proxy sidecar containers that need to be added
to a kubernetes workload (Deployment, DaemonSet, StatefulSet, Job, CronJob, or Pod).  