### PR TITLE
feat: Adds Workload interface to access PodSpec for all workload types 

### DIFF
--- a/internal/workload.go
+++ b/internal/workload.go
@@ -23,27 +23,27 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Workload interface a standard way to access the pod definition for the
+// Workload is a standard way to access the pod definition for the
 // 5 major kinds of interfaces: Deployment, Pod, StatefulSet, Job, and Cronjob.
 // These methods are used by the ModifierStore to update the contents of the
 // workload's pod template (or the pod itself) so that it will contain
 // necessary configuration and other details before it starts, or if the
 // configuration changes.
 type Workload interface {
-	GetPodSpec() corev1.PodSpec
+	PodSpec() corev1.PodSpec
 	SetPodSpec(spec corev1.PodSpec)
-	GetObject() client.Object
+	Object() client.Object
 }
 
 // workloadMatches tests if a workload matches a modifier based on its name, kind, and selectors.
 func workloadMatches(wl Workload, workloadSelector cloudsqlapi.WorkloadSelectorSpec, ns string) bool {
-	if workloadSelector.Kind != "" && wl.GetObject().GetObjectKind().GroupVersionKind().Kind != workloadSelector.Kind {
+	if workloadSelector.Kind != "" && wl.Object().GetObjectKind().GroupVersionKind().Kind != workloadSelector.Kind {
 		return false
 	}
-	if workloadSelector.Name != "" && wl.GetObject().GetName() != workloadSelector.Name {
+	if workloadSelector.Name != "" && wl.Object().GetName() != workloadSelector.Name {
 		return false
 	}
-	if ns != "" && wl.GetObject().GetNamespace() != ns {
+	if ns != "" && wl.Object().GetNamespace() != ns {
 		return false
 	}
 
@@ -51,7 +51,7 @@ func workloadMatches(wl Workload, workloadSelector cloudsqlapi.WorkloadSelectorS
 	if err != nil {
 		return false
 	}
-	if !sel.Empty() && !sel.Matches(labels.Set(wl.GetObject().GetLabels())) {
+	if !sel.Empty() && !sel.Matches(labels.Set(wl.Object().GetLabels())) {
 		return false
 	}
 
@@ -62,7 +62,7 @@ type DeploymentWorkload struct {
 	Deployment *appsv1.Deployment
 }
 
-func (d *DeploymentWorkload) GetPodSpec() corev1.PodSpec {
+func (d *DeploymentWorkload) PodSpec() corev1.PodSpec {
 	return d.Deployment.Spec.Template.Spec
 }
 
@@ -70,7 +70,7 @@ func (d *DeploymentWorkload) SetPodSpec(spec corev1.PodSpec) {
 	d.Deployment.Spec.Template.Spec = spec
 }
 
-func (d *DeploymentWorkload) GetObject() client.Object {
+func (d *DeploymentWorkload) Object() client.Object {
 	return d.Deployment
 }
 
@@ -78,7 +78,7 @@ type StatefulSetWorkload struct {
 	StatefulSet *appsv1.StatefulSet
 }
 
-func (d *StatefulSetWorkload) GetPodSpec() corev1.PodSpec {
+func (d *StatefulSetWorkload) PodSpec() corev1.PodSpec {
 	return d.StatefulSet.Spec.Template.Spec
 }
 
@@ -86,7 +86,7 @@ func (d *StatefulSetWorkload) SetPodSpec(spec corev1.PodSpec) {
 	d.StatefulSet.Spec.Template.Spec = spec
 }
 
-func (d *StatefulSetWorkload) GetObject() client.Object {
+func (d *StatefulSetWorkload) Object() client.Object {
 	return d.StatefulSet
 }
 
@@ -94,7 +94,7 @@ type PodWorkload struct {
 	Pod *corev1.Pod
 }
 
-func (d *PodWorkload) GetPodSpec() corev1.PodSpec {
+func (d *PodWorkload) PodSpec() corev1.PodSpec {
 	return d.Pod.Spec
 }
 
@@ -102,7 +102,7 @@ func (d *PodWorkload) SetPodSpec(spec corev1.PodSpec) {
 	d.Pod.Spec = spec
 }
 
-func (d *PodWorkload) GetObject() client.Object {
+func (d *PodWorkload) Object() client.Object {
 	return d.Pod
 }
 
@@ -110,7 +110,7 @@ type JobWorkload struct {
 	Job *batchv1.Job
 }
 
-func (d *JobWorkload) GetPodSpec() corev1.PodSpec {
+func (d *JobWorkload) PodSpec() corev1.PodSpec {
 	return d.Job.Spec.Template.Spec
 }
 
@@ -118,7 +118,7 @@ func (d *JobWorkload) SetPodSpec(spec corev1.PodSpec) {
 	d.Job.Spec.Template.Spec = spec
 }
 
-func (d *JobWorkload) GetObject() client.Object {
+func (d *JobWorkload) Object() client.Object {
 	return d.Job
 }
 
@@ -126,7 +126,7 @@ type CronJobWorkload struct {
 	CronJob *batchv1.CronJob
 }
 
-func (d *CronJobWorkload) GetPodSpec() corev1.PodSpec {
+func (d *CronJobWorkload) PodSpec() corev1.PodSpec {
 	return d.CronJob.Spec.JobTemplate.Spec.Template.Spec
 }
 
@@ -134,7 +134,7 @@ func (d *CronJobWorkload) SetPodSpec(spec corev1.PodSpec) {
 	d.CronJob.Spec.JobTemplate.Spec.Template.Spec = spec
 }
 
-func (d *CronJobWorkload) GetObject() client.Object {
+func (d *CronJobWorkload) Object() client.Object {
 	return d.CronJob
 }
 
@@ -142,7 +142,7 @@ type DaemonSetWorkload struct {
 	DaemonSet *appsv1.DaemonSet
 }
 
-func (d *DaemonSetWorkload) GetPodSpec() corev1.PodSpec {
+func (d *DaemonSetWorkload) PodSpec() corev1.PodSpec {
 	return d.DaemonSet.Spec.Template.Spec
 }
 
@@ -150,6 +150,6 @@ func (d *DaemonSetWorkload) SetPodSpec(spec corev1.PodSpec) {
 	d.DaemonSet.Spec.Template.Spec = spec
 }
 
-func (d *DaemonSetWorkload) GetObject() client.Object {
+func (d *DaemonSetWorkload) Object() client.Object {
 	return d.DaemonSet
 }

--- a/internal/workload_test.go
+++ b/internal/workload_test.go
@@ -15,7 +15,6 @@
 package internal
 
 import (
-	"log"
 	"testing"
 
 	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/api/v1alpha1"
@@ -40,33 +39,32 @@ func TestWorkloadMatches(t *testing.T) {
 	cases := []testcases{{
 		desc: "match kind, name, and namespace",
 		sel: cloudsqlapi.WorkloadSelectorSpec{
-			Kind:     "Pod",
-			Name:     "hello",
-			Selector: nil,
+			Kind: "Pod",
+			Name: "hello",
 		},
 		tc: []workloadTestCase{
 			{
-				wl:    workload("Pod", "default", "hello"),
+				wl:    workload(t, "Pod", "default", "hello"),
 				match: true,
 				desc:  "matching pod",
 			},
 			{
-				wl:    workload("Pod", "default", "hello", "app", "pod"),
+				wl:    workload(t, "Pod", "default", "hello", "app", "pod"),
 				match: true,
 				desc:  "matching pod with extra label",
 			},
 			{
-				wl:    workload("Pod", "default", "pod", "app", "pod"),
+				wl:    workload(t, "Pod", "default", "pod", "app", "pod"),
 				match: false,
 				desc:  "pod with different name",
 			},
 			{
-				wl:    workload("Pod", "other", "hello"),
+				wl:    workload(t, "Pod", "other", "hello"),
 				match: false,
 				desc:  "pod with different namespace",
 			},
 			{
-				wl:    workload("Deployment", "default", "hello"),
+				wl:    workload(t, "Deployment", "default", "hello"),
 				match: false,
 				desc:  "different kind",
 			},
@@ -76,35 +74,33 @@ func TestWorkloadMatches(t *testing.T) {
 			desc: "match kind, namespace, and labels",
 			sel: cloudsqlapi.WorkloadSelectorSpec{
 				Kind: "Pod",
-				Name: "",
 				Selector: &metav1.LabelSelector{
-					MatchLabels:      map[string]string{"app": "hello"},
-					MatchExpressions: nil,
+					MatchLabels: map[string]string{"app": "hello"},
 				},
 			},
 			tc: []workloadTestCase{
 				{
-					wl:    workload("Pod", "default", "hello"),
+					wl:    workload(t, "Pod", "default", "hello"),
 					match: false,
 					desc:  "label not set",
 				},
 				{
-					wl:    workload("Pod", "default", "hello", "app", "hello", "type", "frontend"),
+					wl:    workload(t, "Pod", "default", "hello", "app", "hello", "type", "frontend"),
 					match: true,
 					desc:  "matching pod with extra label",
 				},
 				{
-					wl:    workload("Pod", "default", "pod", "app", "nope"),
+					wl:    workload(t, "Pod", "default", "pod", "app", "nope"),
 					match: false,
 					desc:  "pod with different label",
 				},
 				{
-					wl:    workload("Pod", "Other", "hello", "app", "hello", "type", "frontend"),
+					wl:    workload(t, "Pod", "Other", "hello", "app", "hello", "type", "frontend"),
 					match: false,
 					desc:  "pod with different namespace",
 				},
 				{
-					wl:    workload("Deployment", "default", "hello", "app", "hello", "type", "frontend"),
+					wl:    workload(t, "Deployment", "default", "hello", "app", "hello", "type", "frontend"),
 					match: false,
 					desc:  "Deploymnet with different namespace",
 				},
@@ -113,36 +109,33 @@ func TestWorkloadMatches(t *testing.T) {
 		{
 			desc: "match namespace, and labels",
 			sel: cloudsqlapi.WorkloadSelectorSpec{
-				Kind: "",
-				Name: "",
 				Selector: &metav1.LabelSelector{
-					MatchLabels:      map[string]string{"app": "hello"},
-					MatchExpressions: nil,
+					MatchLabels: map[string]string{"app": "hello"},
 				},
 			},
 			tc: []workloadTestCase{
 				{
-					wl:    workload("Pod", "default", "hello", "app", "hello", "type", "frontend"),
+					wl:    workload(t, "Pod", "default", "hello", "app", "hello", "type", "frontend"),
 					match: true,
 					desc:  "matching pod with extra label",
 				},
 				{
-					wl:    workload("Pod", "default", "pod", "app", "nope"),
+					wl:    workload(t, "Pod", "default", "pod", "app", "nope"),
 					match: false,
 					desc:  "pod with different label",
 				},
 				{
-					wl:    workload("Deployment", "default", "hello", "app", "hello", "type", "frontend"),
+					wl:    workload(t, "Deployment", "default", "hello", "app", "hello", "type", "frontend"),
 					match: true,
 					desc:  "deployment with extra label",
 				},
 				{
-					wl:    workload("Deployment", "default", "pod", "app", "nope"),
+					wl:    workload(t, "Deployment", "default", "pod", "app", "nope"),
 					match: false,
 					desc:  "deployment with different label",
 				},
 				{
-					wl:    workload("StatefulSet", "default", "things"),
+					wl:    workload(t, "StatefulSet", "default", "things"),
 					match: false,
 					desc:  "StatefulSet no labels",
 				},
@@ -151,10 +144,7 @@ func TestWorkloadMatches(t *testing.T) {
 		{
 			desc: "match namespace, and label expression",
 			sel: cloudsqlapi.WorkloadSelectorSpec{
-				Kind: "",
-				Name: "",
 				Selector: &metav1.LabelSelector{
-					MatchLabels: nil,
 					MatchExpressions: []metav1.LabelSelectorRequirement{{
 						Key:      "app",
 						Operator: metav1.LabelSelectorOpIn,
@@ -164,27 +154,27 @@ func TestWorkloadMatches(t *testing.T) {
 			},
 			tc: []workloadTestCase{
 				{
-					wl:    workload("Pod", "default", "hello", "app", "hello", "type", "frontend"),
+					wl:    workload(t, "Pod", "default", "hello", "app", "hello", "type", "frontend"),
 					match: true,
 					desc:  "matching pod with extra label",
 				},
 				{
-					wl:    workload("Pod", "other", "hello", "app", "hello", "type", "frontend"),
+					wl:    workload(t, "Pod", "other", "hello", "app", "hello", "type", "frontend"),
 					match: false,
 					desc:  "pod with matching label, different namespace",
 				},
 				{
-					wl:    workload("Pod", "default", "pod", "app", "nope"),
+					wl:    workload(t, "Pod", "default", "pod", "app", "nope"),
 					match: false,
 					desc:  "pod with different label",
 				},
 				{
-					wl:    workload("Deployment", "default", "hello", "app", "hello", "type", "frontend"),
+					wl:    workload(t, "Deployment", "default", "hello", "app", "hello", "type", "frontend"),
 					match: true,
 					desc:  "deployment with extra label",
 				},
 				{
-					wl:    workload("Deployment", "default", "pod", "app", "nope"),
+					wl:    workload(t, "Deployment", "default", "pod", "app", "nope"),
 					match: false,
 					desc:  "deployment with different label",
 				},
@@ -206,7 +196,7 @@ func TestWorkloadMatches(t *testing.T) {
 }
 
 // workload is shorthand to create workload test inputs
-func workload(kind string, ns string, name string, l ...string) Workload {
+func workload(t *testing.T, kind string, ns string, name string, l ...string) Workload {
 	var v Workload
 	switch kind {
 	case "Deployment":
@@ -222,19 +212,19 @@ func workload(kind string, ns string, name string, l ...string) Workload {
 	case "DaemonSet":
 		v = &DaemonSetWorkload{DaemonSet: &appsv1.DaemonSet{TypeMeta: metav1.TypeMeta{Kind: "DaemonSet"}}}
 	default:
-		log.Fatalf("Workload kind %s not supported", kind)
+		t.Fatalf("Workload kind %s not supported", kind)
 	}
-	v.GetObject().SetNamespace(ns)
-	v.GetObject().SetName(name)
+	v.Object().SetNamespace(ns)
+	v.Object().SetName(name)
 	if len(l) > 0 {
 		if len(l)%2 != 0 {
-			log.Fatalf("labels list must have an even number of elements")
+			t.Fatalf("labels list must have an even number of elements")
 		}
 		labels := map[string]string{}
 		for i := 0; i < len(l); i += 2 {
 			labels[l[i]] = l[i+1]
 		}
-		v.GetObject().SetLabels(labels)
+		v.Object().SetLabels(labels)
 	}
 
 	return v


### PR DESCRIPTION
Provide a consistent interface Workload and implementations that can access the PodSpec and other common k8s data structure for Pod, Deployment, StatefulSet, DaemonSet, Job, and CronJob.
