### PR TITLE
feat: make default Cloud SQL proxy image calculation plugable (GH-49)

### DIFF
--- a/config/webhook/core_webhook.yaml
+++ b/config/webhook/core_webhook.yaml
@@ -72,5 +72,8 @@ webhooks:
           - jobs
           - cronjobs
         scope: "*"
-    timeoutSeconds: 2
+    # timeoutSeconds is set to 15 seconds in case it needs to query the
+    # container registry for the latest proxy image. Normally this returns under
+    # 2 seconds.
+    timeoutSeconds: 15
     sideEffects: None

--- a/internal/api/v1alpha1/authproxyworkload_types.go
+++ b/internal/api/v1alpha1/authproxyworkload_types.go
@@ -32,6 +32,11 @@ const (
 	// because fuse is not yet supported.
 	ErrorCodeFUSENotSupported = "FUSENotSupported"
 
+	// ErrorCodeDefaultProxyImageMissing occurs when any the default proxy image
+	// cannot be found due to an error loading or interpreting the available
+	// images in the container registry.
+	ErrorCodeDefaultProxyImageMissing = "DefaultProxyImageMissing"
+
 	// AnnotationPrefix is used as the prefix for all annotations added to a domain object.
 	// to hold metadata related to this operator.
 	AnnotationPrefix = "cloudsql.cloud.google.com"

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -28,6 +28,13 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
+type testSupplier struct {
+}
+
+func (s *testSupplier) LatestImage() (string, error) {
+	return "example.com/proxy:latest", nil
+}
+
 func deploymentWorkload() *workload.DeploymentWorkload {
 	return &workload.DeploymentWorkload{Deployment: &appsv1.Deployment{
 		TypeMeta:   metav1.TypeMeta{Kind: "Deployment", APIVersion: "apps/v1"},
@@ -81,7 +88,7 @@ func authProxyWorkloadFromSpec(name string, spec v1alpha1.AuthProxyWorkloadSpec)
 // the appropriate "needs update" annotation to the workload wl for each of the
 // AuthProxyWorkload in proxies.
 func markWorkloadNeedsUpdate(wl *workload.DeploymentWorkload, proxies ...*v1alpha1.AuthProxyWorkload) []*v1alpha1.AuthProxyWorkload {
-	u := workload.NewUpdater()
+	u := workload.NewUpdaterWithSupplier(&testSupplier{})
 	for i := 0; i < len(proxies); i++ {
 		u.MarkWorkloadNeedsUpdate(proxies[i], wl)
 	}
@@ -146,7 +153,7 @@ func TestUpdateWorkload(t *testing.T) {
 		wantsUpdatedInstanceName       = "project:server:newdb"
 		wantsInstanceArg               = fmt.Sprintf("%s?port=%d", wantsInstanceName, wantsPort)
 		wantsUpdatedInstanceArg        = fmt.Sprintf("%s?port=%d", wantsUpdatedInstanceName, wantsPort)
-		u                              = workload.NewUpdater()
+		u                              = workload.NewUpdaterWithSupplier(&testSupplier{})
 	)
 	var err error
 
@@ -244,7 +251,7 @@ func TestUpdateWorkloadFixedPort(t *testing.T) {
 			"DB_HOST": "localhost",
 			"DB_PORT": strconv.Itoa(int(wantsPort)),
 		}
-		u = workload.NewUpdater()
+		u = workload.NewUpdaterWithSupplier(&testSupplier{})
 	)
 
 	// Create a deployment
@@ -315,7 +322,7 @@ func TestWorkloadNoPortSet(t *testing.T) {
 			"DB_PORT": strconv.Itoa(int(wantsPort)),
 		}
 	)
-	u := workload.NewUpdater()
+	u := workload.NewUpdaterWithSupplier(&testSupplier{})
 
 	// Create a deployment
 	wl := deploymentWorkload()
@@ -382,7 +389,7 @@ func TestWorkloadUnixVolume(t *testing.T) {
 		wantWorkloadEnv = map[string]string{
 			"DB_SOCKET_PATH": wantsUnixDir,
 		}
-		u = workload.NewUpdater()
+		u = workload.NewUpdaterWithSupplier(&testSupplier{})
 	)
 
 	// Create a deployment
@@ -460,7 +467,7 @@ func TestContainerImageChanged(t *testing.T) {
 	var (
 		wantsInstanceName = "project:server:db"
 		wantImage         = "custom-image:latest"
-		u                 = workload.NewUpdater()
+		u                 = workload.NewUpdaterWithSupplier(&testSupplier{})
 	)
 
 	// Create a deployment
@@ -507,7 +514,7 @@ func TestContainerReplaced(t *testing.T) {
 		wantContainer     = &corev1.Container{
 			Name: "sample", Image: "debian:latest", Command: []string{"/bin/bash"},
 		}
-		u = workload.NewUpdater()
+		u = workload.NewUpdaterWithSupplier(&testSupplier{})
 	)
 
 	// Create a deployment
@@ -752,7 +759,7 @@ func TestProxyCLIArgs(t *testing.T) {
 	for i := 0; i < len(testcases); i++ {
 		tc := &testcases[i]
 		t.Run(tc.desc, func(t *testing.T) {
-			u := workload.NewUpdater()
+			u := workload.NewUpdaterWithSupplier(&testSupplier{})
 
 			// Create a deployment
 			wl := &workload.DeploymentWorkload{Deployment: &appsv1.Deployment{
@@ -815,7 +822,7 @@ func TestProperCleanupOfEnvAndVolumes(t *testing.T) {
 			"DB_SOCKET_PATH": wantsUnixDir,
 			"DB_PORT":        "5000",
 		}
-		u = workload.NewUpdater()
+		u = workload.NewUpdaterWithSupplier(&testSupplier{})
 	)
 
 	// Create a deployment


### PR DESCRIPTION
Calculate the default proxy image by listing the latest image in the public Container Registry.