### PR TITLE
chore: Add new makefile called operator.mk and generate target

### DIFF
--- a/operator.mk
+++ b/operator.mk
@@ -84,7 +84,7 @@ CONTROLLER_GEN ?= $(LOCALBIN)/controller-gen
 
 ## Tool Versions
 CONTROLLER_TOOLS_VERSION ?= latest
-KUSTOMIZE_VERSION ?= latest
+KUSTOMIZE_VERSION ?= v4.5.2
 
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) # Download controller-gen locally if necessary.


### PR DESCRIPTION
Gradually replacing the existing Makefile with a new one. This change adds the new Makefile and its first targets: help and generate. 
You can run this by running `make -f operator.mk generate`