### PR TITLE
test: convert e2e tests to table test for all workload types (#41 step 3)

### DIFF
--- a/internal/testhelpers/helpers.go
+++ b/internal/testhelpers/helpers.go
@@ -15,6 +15,7 @@
 package testhelpers
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -28,12 +29,12 @@ const DefaultRetryInterval = 5 * time.Second
 
 // CreateOrPatchNamespace ensures that a namespace exists with the given name
 // in kubernetes, or fails the test as fatal.
-func (cc *TestCaseClient) CreateOrPatchNamespace() error {
+func (cc *TestCaseClient) CreateOrPatchNamespace(ctx context.Context) error {
 	var newNS = corev1.Namespace{
 		TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: cc.Namespace},
 	}
-	_, err := controllerutil.CreateOrPatch(cc.Ctx, cc.Client, &newNS, func() error {
+	_, err := controllerutil.CreateOrPatch(ctx, cc.Client, &newNS, func() error {
 		newNS.ObjectMeta.Name = cc.Namespace
 		return nil
 	})
@@ -43,7 +44,7 @@ func (cc *TestCaseClient) CreateOrPatchNamespace() error {
 
 	var gotNS corev1.Namespace
 	err = RetryUntilSuccess(5, DefaultRetryInterval, func() error {
-		return cc.Client.Get(cc.Ctx, client.ObjectKey{Name: cc.Namespace}, &gotNS)
+		return cc.Client.Get(ctx, client.ObjectKey{Name: cc.Namespace}, &gotNS)
 	})
 
 	if err != nil {
@@ -52,13 +53,13 @@ func (cc *TestCaseClient) CreateOrPatchNamespace() error {
 	return nil
 
 }
-func (cc *TestCaseClient) DeleteNamespace() error {
+func (cc *TestCaseClient) DeleteNamespace(ctx context.Context) error {
 	ns := &corev1.Namespace{
 		TypeMeta:   metav1.TypeMeta{Kind: "Namespace", APIVersion: "v1"},
 		ObjectMeta: metav1.ObjectMeta{Name: cc.Namespace},
 	}
 
-	return cc.Client.Delete(cc.Ctx, ns)
+	return cc.Client.Delete(ctx, ns)
 }
 
 // RetryUntilSuccess runs `f` until it no longer returns an error, or it has

--- a/internal/testhelpers/resources.go
+++ b/internal/testhelpers/resources.go
@@ -138,14 +138,14 @@ func BuildCronJob(name types.NamespacedName, appLabel string) *batchv1.CronJob {
 	}
 }
 
-func (cc *TestCaseClient) CreateWorkload(o client.Object) error {
-	err := cc.Client.Create(cc.Ctx, o)
+func (cc *TestCaseClient) CreateWorkload(ctx context.Context, o client.Object) error {
+	err := cc.Client.Create(ctx, o)
 	if err != nil {
 		return err
 	}
 
 	err = RetryUntilSuccess(5, time.Second, func() error {
-		return cc.Client.Get(cc.Ctx, client.ObjectKeyFromObject(o), o)
+		return cc.Client.Get(ctx, client.ObjectKeyFromObject(o), o)
 	})
 	if err != nil {
 		return err
@@ -156,11 +156,11 @@ func (cc *TestCaseClient) CreateWorkload(o client.Object) error {
 // GetAuthProxyWorkloadAfterReconcile finds an AuthProxyWorkload resource named key, waits for its
 // "UpToDate" condition to be "True", and the returns it. Fails after 30 seconds
 // if the containers does not match.
-func (cc *TestCaseClient) GetAuthProxyWorkloadAfterReconcile(key types.NamespacedName) (*v1alpha1.AuthProxyWorkload, error) {
+func (cc *TestCaseClient) GetAuthProxyWorkloadAfterReconcile(ctx context.Context, key types.NamespacedName) (*v1alpha1.AuthProxyWorkload, error) {
 	createdPodmod := &v1alpha1.AuthProxyWorkload{}
 	// We'll need to retry getting this newly created resource, given that creation may not immediately happen.
 	err := RetryUntilSuccess(6, DefaultRetryInterval, func() error {
-		err := cc.Client.Get(cc.Ctx, key, createdPodmod)
+		err := cc.Client.Get(ctx, key, createdPodmod)
 		if err != nil {
 			return err
 		}
@@ -177,18 +177,18 @@ func (cc *TestCaseClient) GetAuthProxyWorkloadAfterReconcile(key types.Namespace
 
 // CreateBusyboxDeployment creates a simple busybox deployment, using the
 // key as its namespace and name. It also sets the label "app"= appLabel.
-func (cc *TestCaseClient) CreateBusyboxDeployment(name types.NamespacedName, appLabel string) (*appsv1.Deployment, error) {
+func (cc *TestCaseClient) CreateBusyboxDeployment(ctx context.Context, name types.NamespacedName, appLabel string) (*appsv1.Deployment, error) {
 
 	d := BuildDeployment(name, appLabel)
 
-	err := cc.Client.Create(cc.Ctx, d)
+	err := cc.Client.Create(ctx, d)
 	if err != nil {
 		return nil, err
 	}
 
 	cd := &appsv1.Deployment{}
 	err = RetryUntilSuccess(5, time.Second, func() error {
-		return cc.Client.Get(cc.Ctx, types.NamespacedName{
+		return cc.Client.Get(ctx, types.NamespacedName{
 			Namespace: name.Namespace,
 			Name:      name.Name,
 		}, cd)
@@ -219,7 +219,7 @@ func ListPods(ctx context.Context, c client.Client, ns string, selector *metav1.
 // ExpectPodContainerCount finds a deployment and keeps checking until the number of
 // containers on the deployment's PodSpec.Containers == count. Returns error after 30 seconds
 // if the containers do not match.
-func (cc *TestCaseClient) ExpectPodContainerCount(podSelector *metav1.LabelSelector, count int, allOrAny string) error {
+func (cc *TestCaseClient) ExpectPodContainerCount(ctx context.Context, podSelector *metav1.LabelSelector, count int, allOrAny string) error {
 
 	var (
 		countBadPods int
@@ -228,7 +228,7 @@ func (cc *TestCaseClient) ExpectPodContainerCount(podSelector *metav1.LabelSelec
 
 	err := RetryUntilSuccess(12, DefaultRetryInterval, func() error {
 		countBadPods = 0
-		pods, err := ListPods(cc.Ctx, cc.Client, cc.Namespace, podSelector)
+		pods, err := ListPods(ctx, cc.Client, cc.Namespace, podSelector)
 		if err != nil {
 			return err
 		}
@@ -261,14 +261,14 @@ func (cc *TestCaseClient) ExpectPodContainerCount(podSelector *metav1.LabelSelec
 // ExpectContainerCount finds a deployment and keeps checking until the number of
 // containers on the deployment's PodSpec.Containers == count. Returns error after 30 seconds
 // if the containers do not match.
-func (cc *TestCaseClient) ExpectContainerCount(key types.NamespacedName, count int) error {
+func (cc *TestCaseClient) ExpectContainerCount(ctx context.Context, key types.NamespacedName, count int) error {
 
 	var (
 		got        int
 		deployment = &appsv1.Deployment{}
 	)
 	err := RetryUntilSuccess(6, DefaultRetryInterval, func() error {
-		err := cc.Client.Get(cc.Ctx, key, deployment)
+		err := cc.Client.Get(ctx, key, deployment)
 		if err != nil {
 			return err
 		}
@@ -290,7 +290,7 @@ func (cc *TestCaseClient) ExpectContainerCount(key types.NamespacedName, count i
 // built into kubernetes. It creates one ReplicaSet and DeploymentSpec.Replicas pods
 // with the correct labels and ownership annotations as if it were in a live cluster.
 // This will make it easier to test and debug the behavior of our pod injection webhooks.
-func (cc *TestCaseClient) CreateDeploymentReplicaSetAndPods(d *appsv1.Deployment) (*appsv1.ReplicaSet, []*corev1.Pod, error) {
+func (cc *TestCaseClient) CreateDeploymentReplicaSetAndPods(ctx context.Context, d *appsv1.Deployment) (*appsv1.ReplicaSet, []*corev1.Pod, error) {
 	podTemplateHash := strconv.FormatUint(rand.Uint64(), 16)
 	rs := &appsv1.ReplicaSet{
 		TypeMeta: metav1.TypeMeta{Kind: "ReplicaSet", APIVersion: "apps/metav1"},
@@ -316,8 +316,12 @@ func (cc *TestCaseClient) CreateDeploymentReplicaSetAndPods(d *appsv1.Deployment
 		},
 	}
 
-	controllerutil.SetOwnerReference(d, rs, cc.Client.Scheme())
-	err := cc.Client.Create(cc.Ctx, rs)
+	err := controllerutil.SetOwnerReference(d, rs, cc.Client.Scheme())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	err = cc.Client.Create(ctx, rs)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -345,8 +349,12 @@ func (cc *TestCaseClient) CreateDeploymentReplicaSetAndPods(d *appsv1.Deployment
 			},
 			Spec: d.Spec.Template.Spec,
 		}
-		controllerutil.SetOwnerReference(rs, p, cc.Client.Scheme())
-		err = cc.Client.Create(cc.Ctx, p)
+		err = controllerutil.SetOwnerReference(rs, p, cc.Client.Scheme())
+		if err != nil {
+			return rs, nil, err
+		}
+
+		err = cc.Client.Create(ctx, p)
 		if err != nil {
 			return rs, nil, err
 		}
@@ -373,7 +381,7 @@ func BuildAuthProxyWorkload(key types.NamespacedName, connectionString string) *
 }
 
 // CreateAuthProxyWorkload creates an AuthProxyWorkload in the kubernetes cluster.
-func (cc *TestCaseClient) CreateAuthProxyWorkload(key types.NamespacedName, appLabel string, connectionString string, kind string) error {
+func (cc *TestCaseClient) CreateAuthProxyWorkload(ctx context.Context, key types.NamespacedName, appLabel string, connectionString string, kind string) error {
 	proxy := BuildAuthProxyWorkload(key, connectionString)
 	proxy.Spec.Workload = v1alpha1.WorkloadSelectorSpec{
 		Kind: kind,
@@ -382,7 +390,7 @@ func (cc *TestCaseClient) CreateAuthProxyWorkload(key types.NamespacedName, appL
 		},
 	}
 	proxy.Spec.AuthProxyContainer = &v1alpha1.AuthProxyContainerSpec{Image: cc.ProxyImageURL}
-	err := cc.Client.Create(cc.Ctx, proxy)
+	err := cc.Client.Create(ctx, proxy)
 	if err != nil {
 		return fmt.Errorf("Unable to create entity %v", err)
 	}

--- a/internal/testhelpers/testcases.go
+++ b/internal/testhelpers/testcases.go
@@ -27,7 +27,6 @@ import (
 )
 
 type TestCaseClient struct {
-	Ctx              context.Context
 	Client           client.Client
 	Namespace        string
 	ConnectionString string
@@ -40,25 +39,23 @@ func NewNamespaceName(prefix string) string {
 
 // CreateResource creates a new workload resource in the TestCaseClient's namespace
 // waits until the resource exists.
-func (cc *TestCaseClient) CreateResource(_ context.Context) (*cloudsqlapi.AuthProxyWorkload, error) {
+func (cc *TestCaseClient) CreateResource(ctx context.Context) (*cloudsqlapi.AuthProxyWorkload, error) {
 	const (
 		name            = "instance1"
 		expectedConnStr = "proj:inst:db"
 	)
-	var (
-		ns = cc.Namespace
-	)
-	err := cc.CreateOrPatchNamespace()
+	ns := cc.Namespace
+	err := cc.CreateOrPatchNamespace(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("can't create namespace, %v", err)
 	}
 	key := types.NamespacedName{Name: name, Namespace: ns}
-	err = cc.CreateAuthProxyWorkload(key, "app", expectedConnStr, "Deployment")
+	err = cc.CreateAuthProxyWorkload(ctx, key, "app", expectedConnStr, "Deployment")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create auth proxy workload %v", err)
 	}
 
-	res, err := cc.GetAuthProxyWorkloadAfterReconcile(key)
+	res, err := cc.GetAuthProxyWorkloadAfterReconcile(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("unable to find entity after create %v", err)
 	}

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -58,7 +58,6 @@ func newTestCaseClient(ns string) *testhelpers.TestCaseClient {
 		Namespace:        testhelpers.NewNamespaceName(ns),
 		ConnectionString: infra.InstanceConnectionString,
 		ProxyImageURL:    proxyImageURL,
-		Ctx:              testContext(),
 	}
 }
 


### PR DESCRIPTION
- test: convert e2e tests to table test for all workload types.
- test: remove unused test helpers and clean up imports.
