### PR TITLE
feat: PodSpec changes now are applied only to pods on creation (#41 step 7)

### DIFF
--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -186,7 +186,7 @@ func (u *Updater) filterMatchingInstances(pl *cloudsqlapi.AuthProxyWorkloadList,
 
 // UpdateWorkloadContainers applies the proxy containers from all of the
 // instances listed in matchingAuthProxyWorkloads to the workload
-func (u *Updater) UpdateWorkloadContainers(wl Workload, matches []*cloudsqlapi.AuthProxyWorkload) (bool, error) {
+func (u *Updater) UpdateWorkloadContainers(wl *PodWorkload, matches []*cloudsqlapi.AuthProxyWorkload) (bool, error) {
 	state := updateState{
 		updater:    u,
 		nextDBPort: DefaultFirstPort,


### PR DESCRIPTION
The proxy configuration is now only applied when a pod is created. The old algorithm allowed updates to the PodSpec
to apply changes after the pod was created. This PR simplifies the logic that applies the proxy configuration to a 
PodSpec, mainly removing the code that would update the pod spec multiple times. 
