### PR TITLE
fix: e2e_cleanup_test_namespaces succeeds when there are no matching namespaces 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -294,7 +294,7 @@ e2e_test_run_gotest:  # Run the golang e2e tests
 .PHONY: e2e_cleanup_test_namespaces
 e2e_cleanup_test_namespaces: e2e_project kustomize kubectl # remove e2e test namespaces named "test*"
 	$(E2E_KUBECTL) get ns -o=name | \
-		grep namespace/test | \
+		grep namespace/test || true | \
 		$(E2E_KUBECTL_ENV) xargs $(KUBECTL) delete
 
 .PHONY: e2e_undeploy


### PR DESCRIPTION
This target should always succeed, even if there are no matching namespaces. The 
`grep` command will fail if there are no results, so the script is updated to be `grep || true`
to hide a failed empty grep from Make.