### PR TITLE
doc: add example configuration for postgres unix and tcp sockets

### DIFF
--- a/docs/example/deployment-postgres-tcp.yaml
+++ b/docs/example/deployment-postgres-tcp.yaml
@@ -1,0 +1,97 @@
+# Copyright 2022 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cloudsql.cloud.google.com/v1alpha1
+kind: AuthProxyWorkload
+metadata:
+  name: authproxyworkload-sample
+spec:
+  workloadSelector:
+    kind: "Deployment"
+    name: "gke-cloud-sql-app"
+  instances:
+  - connectionString: "my-project:us-central1:dbinstance"
+    portEnvName: "DB_PORT"
+    hostEnvName: "DB_HOST"
+    socketType: "tcp"
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gke-cloud-sql-operator-demo
+type: Opaque
+data:
+  DB_PASS: cGFzc3dvcmQ=  # "password"
+  DB_NAME: cG9zdGdyZXM=  # "postgres"
+  DB_USER: dGVzdHVzZXI=  # "testuser"
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gke-cloud-sql-app
+spec:
+  selector:
+    matchLabels:
+      app: gke-cloud-sql-app
+  template:
+    metadata:
+      labels:
+        app: gke-cloud-sql-app
+    spec:
+      containers:
+        - name: gke-cloud-sql-app
+          image: postgres
+          livenessProbe:
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+            exec:
+              command: ["/bin/sh", "-c", "psql --host=$DB_HOST --port=$DB_PORT --username=$DB_USER '--command=select 1' --echo-queries --dbname=$DB_NAME"]
+          command:
+            - "/bin/sh"
+            - "-e"
+            - "-c"
+            - |
+              sleep 10
+              psql --host=$DB_HOST --port=$DB_PORT --username=$DB_USER '--command=select 1' --echo-queries --dbname=$DB_NAME 
+              sleep 3600
+          env:
+            - name: DB_HOST
+              value: "set-by-operator"
+            - name: DB_PORT
+              value: "set-by-operator"
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: gke-cloud-sql-operator-demo
+                  key: DB_USER
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: gke-cloud-sql-operator-demo
+                  key: DB_USER
+            - name: PGPASSWORD # The env name PGPASSWORD is specific to the psql command.
+              valueFrom:
+                secretKeyRef:
+                  name: gke-cloud-sql-operator-demo
+                  key: DB_PASS
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: gke-cloud-sql-operator-demo
+                  key: DB_NAME

--- a/docs/example/deployment-postgres-tcp.yaml
+++ b/docs/example/deployment-postgres-tcp.yaml
@@ -21,25 +21,21 @@ spec:
     kind: "Deployment"
     name: "gke-cloud-sql-app"
   instances:
-  - connectionString: "my-project:us-central1:dbinstance"
-    portEnvName: "DB_PORT"
-    hostEnvName: "DB_HOST"
-    socketType: "tcp"
-
+    - connectionString: "my-project:us-central1:dbinstance"
+      portEnvName: "DB_PORT"
+      hostEnvName: "DB_HOST"
+      socketType: "tcp"
 ---
-
 apiVersion: v1
 kind: Secret
 metadata:
   name: gke-cloud-sql-operator-demo
 type: Opaque
 data:
-  DB_PASS: cGFzc3dvcmQ=  # "password"
-  DB_NAME: cG9zdGdyZXM=  # "postgres"
-  DB_USER: dGVzdHVzZXI=  # "testuser"
-
+  DB_PASS: cGFzc3dvcmQ= # "password"
+  DB_NAME: cG9zdGdyZXM= # "postgres"
+  DB_USER: dGVzdHVzZXI= # "testuser"
 ---
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -66,10 +62,7 @@ spec:
             - "/bin/sh"
             - "-e"
             - "-c"
-            - |
-              sleep 10
-              psql --host=$DB_HOST --port=$DB_PORT --username=$DB_USER '--command=select 1' --echo-queries --dbname=$DB_NAME 
-              sleep 3600
+            - "sleep 10 ; psql --host=$DB_HOST --port=$DB_PORT --username=$DB_USER '--command=select 1' --echo-queries --dbname=$DB_NAME ; sleep 3600"
           env:
             - name: DB_HOST
               value: "set-by-operator"

--- a/docs/example/deployment-postgres-unix.yaml
+++ b/docs/example/deployment-postgres-unix.yaml
@@ -21,25 +21,21 @@ spec:
     kind: "Deployment"
     name: "gke-cloud-sql-app"
   instances:
-  - connectionString: "my-project:us-central1:dbinstance"
-    unixSocketPathEnvName: "DB_SOCKET_PATH"
-    socketType: "unix"
-    unixSocketPath: "/csql/pg"
-
+    - connectionString: "my-project:us-central1:dbinstance"
+      unixSocketPathEnvName: "DB_SOCKET_PATH"
+      socketType: "unix"
+      unixSocketPath: "/csql/pg"
 ---
-
 apiVersion: v1
 kind: Secret
 metadata:
   name: gke-cloud-sql-operator-demo
 type: Opaque
 data:
-  DB_PASS: cGFzc3dvcmQ=  # "password"
-  DB_NAME: cG9zdGdyZXM=  # "postgres"
-  DB_USER: dGVzdHVzZXI=  # "testuser"
-
+  DB_PASS: cGFzc3dvcmQ= # "password"
+  DB_NAME: cG9zdGdyZXM= # "postgres"
+  DB_USER: dGVzdHVzZXI= # "testuser"
 ---
-
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -66,10 +62,7 @@ spec:
             - "/bin/sh"
             - "-e"
             - "-c"
-            - |
-              sleep 20
-              psql --host=$DB_SOCKET_PATH --username=$DB_USER '--command=select 1' --echo-queries --dbname=$DB_NAME 
-              sleep 3600
+            - "sleep 10 ; psql --host=$DB_SOCKET_PATH --username=$DB_USER '--command=select 1' --echo-queries --dbname=$DB_NAME ; sleep 3600"
           env:
             - name: DB_SOCKET_PATH
               value: "set-by-host"

--- a/docs/example/deployment-postgres-unix.yaml
+++ b/docs/example/deployment-postgres-unix.yaml
@@ -1,0 +1,90 @@
+# Copyright 2022 Google LLC.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: cloudsql.cloud.google.com/v1alpha1
+kind: AuthProxyWorkload
+metadata:
+  name: authproxyworkload-sample
+spec:
+  workloadSelector:
+    kind: "Deployment"
+    name: "gke-cloud-sql-app"
+  instances:
+  - connectionString: "my-project:us-central1:dbinstance"
+    unixSocketPathEnvName: "DB_SOCKET_PATH"
+    socketType: "unix"
+    unixSocketPath: "/csql/pg"
+
+---
+
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gke-cloud-sql-operator-demo
+type: Opaque
+data:
+  DB_PASS: cGFzc3dvcmQ=  # "password"
+  DB_NAME: cG9zdGdyZXM=  # "postgres"
+  DB_USER: dGVzdHVzZXI=  # "testuser"
+
+---
+
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gke-cloud-sql-app
+spec:
+  selector:
+    matchLabels:
+      app: gke-cloud-sql-app
+  template:
+    metadata:
+      labels:
+        app: gke-cloud-sql-app
+    spec:
+      containers:
+        - name: gke-cloud-sql-app
+          image: postgres
+          livenessProbe:
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            failureThreshold: 3
+            exec:
+              command: ["/bin/sh", "-c", "psql --host=$DB_SOCKET_PATH --username=$DB_USER '--command=select 1' --echo-queries --dbname=$DB_NAME"]
+          command:
+            - "/bin/sh"
+            - "-e"
+            - "-c"
+            - |
+              sleep 20
+              psql --host=$DB_SOCKET_PATH --username=$DB_USER '--command=select 1' --echo-queries --dbname=$DB_NAME 
+              sleep 3600
+          env:
+            - name: DB_SOCKET_PATH
+              value: "set-by-host"
+            - name: DB_USER
+              valueFrom:
+                secretKeyRef:
+                  name: gke-cloud-sql-operator-demo
+                  key: DB_USER
+            - name: PGPASSWORD # The env name PGPASSWORD is specific to the psql command.
+              valueFrom:
+                secretKeyRef:
+                  name: gke-cloud-sql-operator-demo
+                  key: DB_PASS
+            - name: DB_NAME
+              valueFrom:
+                secretKeyRef:
+                  name: gke-cloud-sql-operator-demo
+                  key: DB_NAME


### PR DESCRIPTION
These files contain deployments and supporting configs to demonstrate that the proxy
container added can actually connect to a real database.