### PR TITLE
fix: host should be '127.0.0.1' not 'localhost'

### DIFF
--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -620,7 +620,7 @@ func (s *updateState) updateContainer(p *cloudsqlapi.AuthProxyWorkload, c *corev
 			if inst.HostEnvName != "" {
 				s.addWorkloadEnvVar(p, inst, corev1.EnvVar{
 					Name:  inst.HostEnvName,
-					Value: "localhost",
+					Value: "127.0.0.1",
 				})
 			}
 			if inst.PortEnvName != "" {

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -247,7 +247,7 @@ func TestUpdateWorkloadFixedPort(t *testing.T) {
 			fmt.Sprintf("%s?port=%d", wantsInstanceName, wantsPort),
 		}
 		wantWorkloadEnv = map[string]string{
-			"DB_HOST": "localhost",
+			"DB_HOST": "127.0.0.1",
 			"DB_PORT": strconv.Itoa(int(wantsPort)),
 		}
 		u = workload.NewUpdater()
@@ -314,7 +314,7 @@ func TestWorkloadNoPortSet(t *testing.T) {
 			fmt.Sprintf("%s?port=%d", wantsInstanceName, wantsPort),
 		}
 		wantWorkloadEnv = map[string]string{
-			"DB_HOST": "localhost",
+			"DB_HOST": "127.0.0.1",
 			"DB_PORT": strconv.Itoa(int(wantsPort)),
 		}
 	)


### PR DESCRIPTION
When a proxy is configured to serve a TCP connection, the application connecting must use the loopback
interface's ip4 address explicitly: `127.0.0.1` instead of the symbolic name `localhost` because `localhost` 
is interpreted differently by different database client libraries. Using `127.0.0.1` instead avoids this ambiguity.

Fixes #124 
