### PR TITLE
fix: Unix socket path should contain the full path to the database socket

### DIFF
--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -16,6 +16,7 @@ package workload
 
 import (
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 
@@ -515,7 +516,7 @@ func (s *updateState) updateContainer(p *cloudsqlapi.AuthProxyWorkload, wl Workl
 			if inst.UnixSocketPathEnvName != "" {
 				s.addWorkloadEnvVar(p, inst, corev1.EnvVar{
 					Name:  inst.UnixSocketPathEnvName,
-					Value: inst.UnixSocketPath,
+					Value: path.Join(inst.UnixSocketPath, inst.ConnectionString),
 				})
 			}
 		}

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -16,6 +16,7 @@ package workload_test
 
 import (
 	"fmt"
+	"path"
 	"reflect"
 	"strconv"
 	"testing"
@@ -315,13 +316,14 @@ func TestWorkloadNoPortSet(t *testing.T) {
 
 func TestWorkloadUnixVolume(t *testing.T) {
 	var (
-		wantsInstanceName = "project:server:db"
-		wantsUnixDir      = "/mnt/db"
-		wantContainerArgs = []string{
+		wantsInstanceName   = "project:server:db"
+		wantsUnixDir        = "/mnt/db"
+		wantsUnixSocketPath = path.Join(wantsUnixDir, wantsInstanceName)
+		wantContainerArgs   = []string{
 			fmt.Sprintf("%s?unix-socket=%s", wantsInstanceName, wantsUnixDir),
 		}
 		wantWorkloadEnv = map[string]string{
-			"DB_SOCKET_PATH": wantsUnixDir,
+			"DB_SOCKET_PATH": wantsUnixSocketPath,
 		}
 		u = workload.NewUpdater()
 	)


### PR DESCRIPTION
The per-instance CLI parameter `unix-socket` contains only the directory where the unix socket should go,
not the entire path to the socket. The operator should set the environment variable for the unix socket path to
be the complete path to the socket. The customer should not need to append the database connection string.

Fixes #125