### PR TITLE
chore: attempt to fix the release-please github workflow

### DIFF
--- a/.github/workflows/release-please-updates.yaml
+++ b/.github/workflows/release-please-updates.yaml
@@ -24,7 +24,7 @@ jobs:
       - name: Print Actor
         uses: actions/github-script@v6
         with:
-          script: console.log("The github actor is ", github.actor);
+          script: console.log("The github actor is ${{github.actor}}");
       - name: Setup Go
         uses: actions/setup-go@v3
         with:


### PR DESCRIPTION
The github workflow should only run when the github.actor is release-please. Unfortunately for bots the actor name differs from the username. So this should help us figure out what is the real actor name for our release-please actor.