### PR TITLE
fix: change memory resource to match recommendations Cloud SQL Proxy

### DIFF
--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -121,7 +121,7 @@ func (e *ConfigErrorDetail) Error() string {
 var defaultContainerResources = corev1.ResourceRequirements{
 	Requests: corev1.ResourceList{
 		"cpu":    resource.MustParse("1.0"),
-		"memory": resource.MustParse("1Gi"),
+		"memory": resource.MustParse("2Gi"),
 	},
 }
 


### PR DESCRIPTION
The Cloud SQL Proxy project recommends 2Gi for ram. This changes the default resource requirements to match.