### PR TITLE
test: add a test to cover resource requirements from spec.

### DIFF
--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -474,7 +474,7 @@ func TestResourcesFromSpec(t *testing.T) {
 			},
 		}
 
-		u = workload.NewUpdater()
+		u = workload.NewUpdater("cloud-sql-proxy-operator/dev")
 	)
 
 	// Create a pod


### PR DESCRIPTION
While pruning fields from the CRD, I found some uncovered code that needed a test.
This adds a test case to make sure that when a customer sets the proxy container resource
requirements in the CRD, the values are actually set on the container.