### PR TITLE
doc: update the Quick Start guide with the workaround for GKE Autopilot 

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,5 @@
 # Cloud SQL Proxy Operator
 
-*Warning*: This project is in Public Preview, and may contain breaking changes
-before it becomes Generally Available.
-
 Cloud SQL Proxy Operator is an open-source Kubernetes operator that automates
 most of the intricate steps needed to connect a workload in a kubernetes cluster
 to Cloud SQL databases. 
@@ -23,11 +20,27 @@ Confirm that kubectl can connect to your kubernetes cluster.
 kubectl cluster-info
 ```
 
+Install cert-manager using helm. Note that you need to use this particular 
+version with these specific cli arguments to make cert-manager work on 
+your GKE cluster.
+
+```shell
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --version "v1.9.1" \
+  --create-namespace \
+  --set global.leaderElection.namespace=cert-manager \
+  --set installCRDs=true
+```
+
 Run the following command to install the cloud sql proxy operator into
 your kubernetes cluster:
 
 ```shell
-curl https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy-operator/v0.1.0/install.sh | bash
+kubectl apply -f https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy-operator/v0.1.0/cloud-sql-proxy-operator.yaml
 ```
 
 Confirm that the operator is installed and running by listing its pods:
@@ -80,10 +93,10 @@ considered publicly unsupported.
 
 ## Contributing
 
-Contributions are welcome. Please, see the [Contributing](docs/contributing.md) document
+Contributions are welcome. Please, see the [CONTRIBUTING][contributing] document
 for details.
 
 Please note that this project is released with a Contributor Code of Conduct.
 By participating in this project you agree to abide by its terms.  See
-[Code of Conduct](docs/code-of-conduct.md) for more information.
+[Contributor Code of Conduct][code-of-conduct] for more information.
 

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -16,11 +16,33 @@ Confirm that kubectl can connect to the cluster.
 kubectl cluster-info
 ```
 
-Run the following command to install the cloud sql proxy operator into
-your kuberentes cluster:
+Install cert-manager using helm. Note that because you are using a GKE
+Autopilot cluster, you need to use this particular version with these specific
+cli arguments to make cert-manager work on your GKE Autopilot cluster. 
 
 ```shell
-curl https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy-operator/v0.1.0/install.sh | bash
+helm repo add jetstack https://charts.jetstack.io
+helm repo update
+helm install \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --version "v1.9.1" \
+  --create-namespace \
+  --set global.leaderElection.namespace=cert-manager \
+  --set installCRDs=true
+```
+
+Run the following command to install the cloud sql proxy operator into
+your kubernetes cluster:
+
+```shell
+curl https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy-operator/v0.1.0/cloud-sql-proxy-operator.yaml | bash
+```
+
+Wait for the Cloud SQL Auth Proxy Operator to start.
+
+```shell
+kubectl rollout status deployment -n cloud-sql-proxy-operator-system cloud-sql-proxy-operator-controller-manager --timeout=90s
 ```
 
 Confirm that the operator is installed and running by listing its pods:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -66,22 +66,22 @@ apiVersion: cloudsql.cloud.google.com/v1alpha1
 kind: AuthProxyWorkload
 metadata:
   name: authproxyworkload-sample
-  -spec:
+spec:
   workloadSelector:
     kind: "Deployment"
     name: "gke-cloud-sql-quickstart"
   instances:
-    - connectionString: "<INSTANCE_CONNECTION_NAME>"
-      portEnvName: "DB_PORT"
-      hostEnvName: "INSTANCE_HOST"
+  - connectionString: "<INSTANCE_CONNECTION_NAME>"
+    portEnvName: "DB_PORT"
+    hostEnvName: "INSTANCE_HOST"
 ```
 
 Update <INSTANCE_CONNECTION_NAME> with the Cloud SQL instance connection name
-retrieved from the gcloud command on the previous step. The format is
+retrieved from the gcloud command on the previous step. This should follow the format
 project_id:region:instance_name. The instance connection name is also visible
-in the Cloud SQL instance Overview page.
+in the Google Cloud Console on the Cloud SQL Instance Overview page.
 
-Apply the proxy configuration to to kubernetes:
+Apply the proxy configuration to kubernetes:
 
 ```shell
 kubectl apply -f authproxyworkload.yaml


### PR DESCRIPTION
This updates the Quick Start guide adding a few extra steps to work around 
the problem that the installer does not work on GKE Autopilot clusters. 

This explains to the user how to use the helm chart for cert-manager to make it
install correctly on GKE. 

Related to #157