### PR TITLE
chore: only update the version in the docs on a new release.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ help: ## Display this help.
 install_tools: remove_tools all_tools ## Installs all development tools
 
 .PHONY: generate
-generate:  ctrl_generate ctrl_manifests go_lint tf_lint installer reset_image add_copyright_header update_version_in_docs go_fmt yaml_fmt ## Runs code generation, format, and validation tools
+generate:  ctrl_generate ctrl_manifests go_lint tf_lint installer reset_image add_copyright_header go_fmt yaml_fmt ## Runs code generation, format, and validation tools
 
 .PHONY: build
 build: generate build_push_docker ## Builds and pushes the docker image to tag defined in envvar IMG

--- a/tools/release-pr-generate.sh
+++ b/tools/release-pr-generate.sh
@@ -19,7 +19,7 @@ PROJECT_DIR=$( dirname "$SCRIPT_DIR")
 
 cd "$PROJECT_DIR"
 
-make generate
+make update_version_in_docs generate
 
 if git diff --exit-code ; then
   echo "Generate did not cause any changes to the code. OK to proceed with the release"


### PR DESCRIPTION
When a user lands on this repo and reads the README or Quick Start Guide, the instructions
should point the user to the latest released version of the proxy, not the current dev version.

This PR updates `make generate` so that it does not automatically update the version in documentation,
leaving the latest release version in the docs.

It also updates the release-please-updates job that generates code after the release PR is
created to update the version in docs along with running `make generate`