### PR TITLE
doc: Automatically generate API documentation for the AuthProxyWorkload

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ to know all the details to configure your proxy.
 
 ## Reference Documentation
 - [Quick Start Guide](docs/quick-start.md)
+- [API Documentation](docs/api.md)
 - [Cloud SQL Proxy](/GoogleCloudPlatform/cloud-sql-proxy)
 - [Developer Getting Started](docs/dev.md)
 - [Developing End-to-End tests](docs/e2e-tests.md)

--- a/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
+++ b/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
@@ -30,7 +30,7 @@ spec:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: AuthProxyWorkload declares how a Cloud SQL Proxy container should be applied to a matching set of workloads, and shows the status of those proxy containers. This is the Schema for the authproxyworkloads API.
+          description: AuthProxyWorkload declares how a Cloud SQL Proxy container should be applied to a matching set of workloads, and shows the status of those proxy containers.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -41,10 +41,10 @@ spec:
             metadata:
               type: object
             spec:
-              description: AuthProxyWorkloadSpec defines the desired state of AuthProxyWorkload
+              description: AuthProxyWorkloadSpec describes where and how to configure the proxy.
               properties:
                 authProxyContainer:
-                  description: AuthProxyContainer describes the resources and config for the Auth Proxy container
+                  description: AuthProxyContainer describes the resources and config for the Auth Proxy container.
                   properties:
                     container:
                       description: Container is debugging parameter that when specified will override the proxy container with a completely custom Container spec.
@@ -912,28 +912,28 @@ spec:
                       type: object
                   type: object
                 instances:
-                  description: Instances lists the Cloud SQL instances to connect
+                  description: Instances describes the Cloud SQL instances to configure on the proxy container.
                   items:
-                    description: "InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. The simplest possible configuration declares just the connection string and the port number or unix socket. \n For example, for a TCP port: \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"port\":5000 } \n or for a unix socket: \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"unixSocketPath\" : \"/mnt/db/my-db-server\" } \n You may allow the operator to choose a non-conflicting TCP port or unix socket instead of explicitly setting the port or socket path. This may be easier to manage when workload needs to connect to many databases. \n For example, for a TCP port: \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"portEnvName\":\"MY_DB_SERVER_PORT\" \"hostEnvName\":\"MY_DB_SERVER_HOST\" } \n will set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. Then, the application can read these values to connect to the database through the proxy. \n or for a unix socket: \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"unixSocketPathEnvName\" : \"MY_DB_SERVER_SOCKET_DIR\" } \n will set environment variables MY_DB_SERVER_SOCKET_DIR with the value of the unix socket path. Then, the application can read this value to connect to the database through the proxy."
+                    description: "InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. \n In the minimum recommended configuration, the operator will choose a non-conflicting TCP port and set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. The application can read these values to connect to the database through the proxy. \n ``` \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"portEnvName\":\"MY_DB_SERVER_PORT\" \"hostEnvName\":\"MY_DB_SERVER_HOST\" } \n ``` \n If you want to assign a specific port number for a database, set the `port` field. For example: \n ``` { \"connectionString\":\"my-project:us-central1:my-db-server\", \"port\":5000 } ```"
                     properties:
                       autoIAMAuthN:
-                        description: AutoIAMAuthN Enables IAM Authentication for this instance. Optional, default false.
+                        description: AutoIAMAuthN (optional) Enables IAM Authentication for this instance. Default value is false.
                         type: boolean
                       connectionString:
-                        description: ConnectionString is the Cloud SQL instance.
+                        description: ConnectionString is the connection string for the Cloud SQL Instance in the format `project_id:region:instance_name`
                         type: string
                       hostEnvName:
                         description: HostEnvName The name of the environment variable containing this instances tcp hostname Optional, when set this environment variable will be added to all containers in the workload.
                         type: string
                       port:
-                        description: Port sets the tcp port for this instance. Optional, if not set, a value will be automatically assigned by the operator and set as an environment variable on all containers in the workload named according to PortEnvName. The operator will choose a port so that it does not conflict with other ports on the workload.
+                        description: Port (optional) sets the tcp port for this instance. If not set, a value will be automatically assigned by the operator and set as an environment variable on all containers in the workload named according to PortEnvName. The operator will choose a port so that it does not conflict with other ports on the workload.
                         format: int32
                         type: integer
                       portEnvName:
                         description: PortEnvName is name of the environment variable containing this instance's tcp port. Optional, when set this environment variable will be added to all containers in the workload.
                         type: string
                       privateIP:
-                        description: PrivateIP Enable connection to the Cloud SQL instance's private ip for this instance. Optional, default false.
+                        description: PrivateIP (optional) Enable connection to the Cloud SQL instance's private ip for this instance. Default value is false.
                         type: boolean
                       unixSocketPath:
                         description: UnixSocketPath is the path to the unix socket where the proxy will listen for connnections. This will be mounted to all containers in the pod.
@@ -945,7 +945,7 @@ spec:
                   minItems: 1
                   type: array
                 workloadSelector:
-                  description: Workload selects the workload to
+                  description: Workload selects the workload where the proxy container will be added.
                   properties:
                     kind:
                       description: 'Kind specifies what kind of workload Supported kinds: Deployment, StatefulSet, Pod, ReplicaSet,DaemonSet, Job, CronJob Example: "Deployment" "Deployment.v1" or "Deployment.v1.apps".'

--- a/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
+++ b/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
@@ -914,7 +914,7 @@ spec:
                 instances:
                   description: Instances describes the Cloud SQL instances to configure on the proxy container.
                   items:
-                    description: "InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. \n In the minimum recommended configuration, the operator will choose a non-conflicting TCP port and set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. The application can read these values to connect to the database through the proxy. \n ``` \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"portEnvName\":\"MY_DB_SERVER_PORT\" \"hostEnvName\":\"MY_DB_SERVER_HOST\" } \n ``` \n If you want to assign a specific port number for a database, set the `port` field. For example: \n ``` { \"connectionString\":\"my-project:us-central1:my-db-server\", \"port\":5000 } ```"
+                    description: "InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. \n In the minimum recommended configuration, the operator will choose a non-conflicting TCP port and set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. The application can read these values to connect to the database through the proxy. For example: \n `{ \"connectionString\":\"my-project:us-central1:my-db-server\", \"portEnvName\":\"MY_DB_SERVER_PORT\" \"hostEnvName\":\"MY_DB_SERVER_HOST\" }` \n If you want to assign a specific port number for a database, set the `port` field. For example: \n `{ \"connectionString\":\"my-project:us-central1:my-db-server\", \"port\":5000 }`"
                     properties:
                       autoIAMAuthN:
                         description: AutoIAMAuthN (optional) Enables IAM Authentication for this instance. Default value is false.
@@ -955,7 +955,7 @@ spec:
                       description: Name specifies the name of the resource to select.
                       type: string
                     selector:
-                      description: Selector selects resources using labels. See "Label selectors" in the kubernetes docs https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                      description: Selector (optional) selects resources using labels. See "Label selectors" in the kubernetes docs https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.

--- a/docs/api.md
+++ b/docs/api.md
@@ -6,9 +6,8 @@
 
 ## cloudsql.cloud.google.com/v1alpha1
 
-Package v1alpha1 contains API Schema definitions for the cloudsql v1alpha1 API group:
-the custom resource AuthProxyWorkload version v1alpha1
-This follows the kubebuilder pattern for defining custom resources.
+Package v1alpha1 contains the API Schema definitions for the
+the custom resource AuthProxyWorkload version v1alpha1.
 
 
 ### Resource Types
@@ -20,7 +19,7 @@ This follows the kubebuilder pattern for defining custom resources.
 
 
 
-AuthProxyContainerSpec specifies configuration for the proxy container.
+AuthProxyContainerSpec describes how to configure global proxy configuration and kubernetes-specific container configuration.
 
 _Appears in:_
 - [AuthProxyWorkloadSpec](#authproxyworkloadspec)
@@ -29,17 +28,19 @@ _Appears in:_
 | --- | --- |
 | `container` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#container-v1-core)_ | Container is debugging parameter that when specified will override the proxy container with a completely custom Container spec. |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core)_ | Resources specifies the resources required for the proxy pod. |
+| `telemetry` _[TelemetrySpec](#telemetryspec)_ | Telemetry specifies how the proxy should expose telemetry. Optional, by default |
 | `maxConnections` _integer_ | MaxConnections limits the number of connections. Default value is no limit. This sets the proxy container's CLI argument `--max-connections` |
 | `maxSigtermDelay` _integer_ | MaxSigtermDelay is the maximum number of seconds to wait for connections to close after receiving a TERM signal. This sets the proxy container's CLI argument `--max-sigterm-delay` and configures `terminationGracePeriodSeconds` on the workload's PodSpec. |
 | `sqlAdminAPIEndpoint` _string_ | SQLAdminAPIEndpoint is a debugging parameter that when specified will change the Google Cloud api endpoint used by the proxy. |
 | `image` _string_ | Image is the URL to the proxy image. Optional, by default the operator will use the latest known compatible proxy image. |
+| `rolloutStrategy` _string_ | RolloutStrategy indicates the strategy to use when rolling out changes to the workloads affected by the results. When this is set to `Workload`, changes to this resource will be automatically applied to a running Deployment, StatefulSet, DaemonSet, or ReplicaSet in accordance with the Strategy set on that workload. When this is set to `None`, the operator will take no action to roll out changes to affected workloads. `Workload` will be used by default if no value is set. See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
 
 
 #### AuthProxyWorkload
 
 
 
-AuthProxyWorkload declares how a Cloud SQL Proxy container should be applied to a matching set of workloads, and shows the status of those proxy containers. This is the Schema for the authproxyworkloads API.
+AuthProxyWorkload declares how a Cloud SQL Proxy container should be applied to a matching set of workloads, and shows the status of those proxy containers.
 
 
 
@@ -55,53 +56,64 @@ AuthProxyWorkload declares how a Cloud SQL Proxy container should be applied to 
 
 
 
-AuthProxyWorkloadSpec defines the desired state of AuthProxyWorkload
+AuthProxyWorkloadSpec describes where and how to configure the proxy.
 
 _Appears in:_
 - [AuthProxyWorkload](#authproxyworkload)
 
 | Field | Description |
 | --- | --- |
-| `workloadSelector` _[WorkloadSelectorSpec](#workloadselectorspec)_ | Workload selects the workload to |
-| `authProxyContainer` _[AuthProxyContainerSpec](#authproxycontainerspec)_ | AuthProxyContainer describes the resources and config for the Auth Proxy container |
-| `instances` _[InstanceSpec](#instancespec) array_ | Instances lists the Cloud SQL instances to connect |
+| `workloadSelector` _[WorkloadSelectorSpec](#workloadselectorspec)_ | Workload selects the workload where the proxy container will be added. |
+| `instances` _[InstanceSpec](#instancespec) array_ | Instances describes the Cloud SQL instances to configure on the proxy container. |
+| `authProxyContainer` _[AuthProxyContainerSpec](#authproxycontainerspec)_ | AuthProxyContainer describes the resources and config for the Auth Proxy container. |
 
 
 #### InstanceSpec
 
 
 
-InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. The simplest possible configuration declares just the connection string and the port number or unix socket. 
- For example, for a TCP port: 
- 	{ "connectionString":"my-project:us-central1:my-db-server", "port":5000 } 
- or for a unix socket: 
- 	{ "connectionString":"my-project:us-central1:my-db-server", 	  "unixSocketPath" : "/mnt/db/my-db-server" } 
- You may allow the operator to choose a non-conflicting TCP port or unix socket instead of explicitly setting the port or socket path. This may be easier to manage when workload needs to connect to many databases. 
- For example, for a TCP port: 
- 	{ "connectionString":"my-project:us-central1:my-db-server", 	  "portEnvName":"MY_DB_SERVER_PORT" 	  "hostEnvName":"MY_DB_SERVER_HOST" 	 } 
- will set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. Then, the application can read these values to connect to the database through the proxy. 
- or for a unix socket: 
- 	{ "connectionString":"my-project:us-central1:my-db-server", 	  "unixSocketPathEnvName" : "MY_DB_SERVER_SOCKET_DIR" } 
- will set environment variables MY_DB_SERVER_SOCKET_DIR with the value of the unix socket path. Then, the application can read this value to connect to the database through the proxy.
+InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. 
+ In the minimum recommended configuration, the operator will choose a non-conflicting TCP port and set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. The application can read these values to connect to the database through the proxy. 
+ ``` 
+ 	{ 	   "connectionString":"my-project:us-central1:my-db-server", 	   "portEnvName":"MY_DB_SERVER_PORT" 	   "hostEnvName":"MY_DB_SERVER_HOST" 	} 
+ ``` 
+ If you want to assign a specific port number for a database, set the `port` field. For example: 
+ 	``` 	{ "connectionString":"my-project:us-central1:my-db-server", "port":5000 } 	```
 
 _Appears in:_
 - [AuthProxyWorkloadSpec](#authproxyworkloadspec)
 
 | Field | Description |
 | --- | --- |
-| `connectionString` _string_ | ConnectionString is the Cloud SQL instance. |
-| `port` _integer_ | Port sets the tcp port for this instance. Optional, if not set, a value will be automatically assigned by the operator and set as an environment variable on all containers in the workload named according to PortEnvName. The operator will choose a port so that it does not conflict with other ports on the workload. |
-| `autoIAMAuthN` _boolean_ | AutoIAMAuthN Enables IAM Authentication for this instance. Optional, default false. |
-| `privateIP` _boolean_ | PrivateIP Enable connection to the Cloud SQL instance's private ip for this instance. Optional, default false. |
+| `connectionString` _string_ | ConnectionString is the connection string for the Cloud SQL Instance in the format `project_id:region:instance_name` |
+| `port` _integer_ | Port (optional) sets the tcp port for this instance. If not set, a value will be automatically assigned by the operator and set as an environment variable on all containers in the workload named according to PortEnvName. The operator will choose a port so that it does not conflict with other ports on the workload. |
+| `autoIAMAuthN` _boolean_ | AutoIAMAuthN (optional) Enables IAM Authentication for this instance. Default value is false. |
+| `privateIP` _boolean_ | PrivateIP (optional) Enable connection to the Cloud SQL instance's private ip for this instance. Default value is false. |
 | `portEnvName` _string_ | PortEnvName is name of the environment variable containing this instance's tcp port. Optional, when set this environment variable will be added to all containers in the workload. |
 | `hostEnvName` _string_ | HostEnvName The name of the environment variable containing this instances tcp hostname Optional, when set this environment variable will be added to all containers in the workload. |
+| `unixSocketPath` _string_ | UnixSocketPath is the path to the unix socket where the proxy will listen for connnections. This will be mounted to all containers in the pod. |
+| `unixSocketPathEnvName` _string_ | UnixSocketPathEnvName is the environment variable containing the value of UnixSocketPath. |
+
+
+#### TelemetrySpec
+
+
+
+TelemetrySpec specifies how the proxy container will expose telemetry.
+
+_Appears in:_
+- [AuthProxyContainerSpec](#authproxycontainerspec)
+
+| Field | Description |
+| --- | --- |
+| `httpPort` _integer_ | HTTPPort the port for Prometheus and health check server. This sets the proxy container's CLI argument `--http-port` |
 
 
 #### WorkloadSelectorSpec
 
 
 
-WorkloadSelectorSpec describes which workloads should be configured with this proxy configuration. To be valid, WorkloadSelectorSpec must specify Kind and either Name or Selector.
+WorkloadSelectorSpec describes which workloads should be configured with this proxy configuration. To be valid, WorkloadSelectorSpec must specify `Kind` and either `Name` or `Selector`.
 
 _Appears in:_
 - [AuthProxyWorkloadSpec](#authproxyworkloadspec)
@@ -110,7 +122,6 @@ _Appears in:_
 | --- | --- |
 | `selector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta)_ | Selector selects resources using labels. See "Label selectors" in the kubernetes docs https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors |
 | `kind` _string_ | Kind specifies what kind of workload Supported kinds: Deployment, StatefulSet, Pod, ReplicaSet,DaemonSet, Job, CronJob Example: "Deployment" "Deployment.v1" or "Deployment.v1.apps". |
-| `namespace` _string_ | Namespace specifies namespace in which to select the resource. Optional, defaults to the namespace of the AuthProxyWorkload resource. All or Wildcard namespaces are not supported. |
 | `name` _string_ | Name specifies the name of the resource to select. |
 
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -73,12 +73,10 @@ _Appears in:_
 
 
 InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. 
- In the minimum recommended configuration, the operator will choose a non-conflicting TCP port and set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. The application can read these values to connect to the database through the proxy. 
- ``` 
- 	{ 	   "connectionString":"my-project:us-central1:my-db-server", 	   "portEnvName":"MY_DB_SERVER_PORT" 	   "hostEnvName":"MY_DB_SERVER_HOST" 	} 
- ``` 
+ In the minimum recommended configuration, the operator will choose a non-conflicting TCP port and set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. The application can read these values to connect to the database through the proxy. For example: 
+ 	`{ 			   "connectionString":"my-project:us-central1:my-db-server", 			   "portEnvName":"MY_DB_SERVER_PORT" 			   "hostEnvName":"MY_DB_SERVER_HOST" 	}` 
  If you want to assign a specific port number for a database, set the `port` field. For example: 
- 	``` 	{ "connectionString":"my-project:us-central1:my-db-server", "port":5000 } 	```
+ 	`{ "connectionString":"my-project:us-central1:my-db-server", "port":5000 }`
 
 _Appears in:_
 - [AuthProxyWorkloadSpec](#authproxyworkloadspec)
@@ -113,14 +111,14 @@ _Appears in:_
 
 
 
-WorkloadSelectorSpec describes which workloads should be configured with this proxy configuration. To be valid, WorkloadSelectorSpec must specify `Kind` and either `Name` or `Selector`.
+WorkloadSelectorSpec describes which workloads should be configured with this proxy configuration. To be valid, WorkloadSelectorSpec must specify `kind` and either `name` or `selector`.
 
 _Appears in:_
 - [AuthProxyWorkloadSpec](#authproxyworkloadspec)
 
 | Field | Description |
 | --- | --- |
-| `selector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta)_ | Selector selects resources using labels. See "Label selectors" in the kubernetes docs https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors |
+| `selector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta)_ | Selector (optional) selects resources using labels. See "Label selectors" in the kubernetes docs https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors |
 | `kind` _string_ | Kind specifies what kind of workload Supported kinds: Deployment, StatefulSet, Pod, ReplicaSet,DaemonSet, Job, CronJob Example: "Deployment" "Deployment.v1" or "Deployment.v1.apps". |
 | `name` _string_ | Name specifies the name of the resource to select. |
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,0 +1,118 @@
+# API Reference
+
+## Packages
+- [cloudsql.cloud.google.com/v1alpha1](#cloudsqlcloudgooglecomv1alpha1)
+
+
+## cloudsql.cloud.google.com/v1alpha1
+
+Package v1alpha1 contains API Schema definitions for the cloudsql v1alpha1 API group:
+the custom resource AuthProxyWorkload version v1alpha1
+This follows the kubebuilder pattern for defining custom resources.
+
+
+### Resource Types
+- [AuthProxyWorkload](#authproxyworkload)
+
+
+
+#### AuthProxyContainerSpec
+
+
+
+AuthProxyContainerSpec specifies configuration for the proxy container.
+
+_Appears in:_
+- [AuthProxyWorkloadSpec](#authproxyworkloadspec)
+
+| Field | Description |
+| --- | --- |
+| `container` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#container-v1-core)_ | Container is debugging parameter that when specified will override the proxy container with a completely custom Container spec. |
+| `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core)_ | Resources specifies the resources required for the proxy pod. |
+| `maxConnections` _integer_ | MaxConnections limits the number of connections. Default value is no limit. This sets the proxy container's CLI argument `--max-connections` |
+| `maxSigtermDelay` _integer_ | MaxSigtermDelay is the maximum number of seconds to wait for connections to close after receiving a TERM signal. This sets the proxy container's CLI argument `--max-sigterm-delay` and configures `terminationGracePeriodSeconds` on the workload's PodSpec. |
+| `sqlAdminAPIEndpoint` _string_ | SQLAdminAPIEndpoint is a debugging parameter that when specified will change the Google Cloud api endpoint used by the proxy. |
+| `image` _string_ | Image is the URL to the proxy image. Optional, by default the operator will use the latest known compatible proxy image. |
+
+
+#### AuthProxyWorkload
+
+
+
+AuthProxyWorkload declares how a Cloud SQL Proxy container should be applied to a matching set of workloads, and shows the status of those proxy containers. This is the Schema for the authproxyworkloads API.
+
+
+
+| Field | Description |
+| --- | --- |
+| `apiVersion` _string_ | `cloudsql.cloud.google.com/v1alpha1`
+| `kind` _string_ | `AuthProxyWorkload`
+| `metadata` _[ObjectMeta](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#objectmeta-v1-meta)_ | Refer to Kubernetes API documentation for fields of `metadata`. |
+| `spec` _[AuthProxyWorkloadSpec](#authproxyworkloadspec)_ |  |
+
+
+#### AuthProxyWorkloadSpec
+
+
+
+AuthProxyWorkloadSpec defines the desired state of AuthProxyWorkload
+
+_Appears in:_
+- [AuthProxyWorkload](#authproxyworkload)
+
+| Field | Description |
+| --- | --- |
+| `workloadSelector` _[WorkloadSelectorSpec](#workloadselectorspec)_ | Workload selects the workload to |
+| `authProxyContainer` _[AuthProxyContainerSpec](#authproxycontainerspec)_ | AuthProxyContainer describes the resources and config for the Auth Proxy container |
+| `instances` _[InstanceSpec](#instancespec) array_ | Instances lists the Cloud SQL instances to connect |
+
+
+#### InstanceSpec
+
+
+
+InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. The simplest possible configuration declares just the connection string and the port number or unix socket. 
+ For example, for a TCP port: 
+ 	{ "connectionString":"my-project:us-central1:my-db-server", "port":5000 } 
+ or for a unix socket: 
+ 	{ "connectionString":"my-project:us-central1:my-db-server", 	  "unixSocketPath" : "/mnt/db/my-db-server" } 
+ You may allow the operator to choose a non-conflicting TCP port or unix socket instead of explicitly setting the port or socket path. This may be easier to manage when workload needs to connect to many databases. 
+ For example, for a TCP port: 
+ 	{ "connectionString":"my-project:us-central1:my-db-server", 	  "portEnvName":"MY_DB_SERVER_PORT" 	  "hostEnvName":"MY_DB_SERVER_HOST" 	 } 
+ will set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. Then, the application can read these values to connect to the database through the proxy. 
+ or for a unix socket: 
+ 	{ "connectionString":"my-project:us-central1:my-db-server", 	  "unixSocketPathEnvName" : "MY_DB_SERVER_SOCKET_DIR" } 
+ will set environment variables MY_DB_SERVER_SOCKET_DIR with the value of the unix socket path. Then, the application can read this value to connect to the database through the proxy.
+
+_Appears in:_
+- [AuthProxyWorkloadSpec](#authproxyworkloadspec)
+
+| Field | Description |
+| --- | --- |
+| `connectionString` _string_ | ConnectionString is the Cloud SQL instance. |
+| `port` _integer_ | Port sets the tcp port for this instance. Optional, if not set, a value will be automatically assigned by the operator and set as an environment variable on all containers in the workload named according to PortEnvName. The operator will choose a port so that it does not conflict with other ports on the workload. |
+| `autoIAMAuthN` _boolean_ | AutoIAMAuthN Enables IAM Authentication for this instance. Optional, default false. |
+| `privateIP` _boolean_ | PrivateIP Enable connection to the Cloud SQL instance's private ip for this instance. Optional, default false. |
+| `portEnvName` _string_ | PortEnvName is name of the environment variable containing this instance's tcp port. Optional, when set this environment variable will be added to all containers in the workload. |
+| `hostEnvName` _string_ | HostEnvName The name of the environment variable containing this instances tcp hostname Optional, when set this environment variable will be added to all containers in the workload. |
+
+
+#### WorkloadSelectorSpec
+
+
+
+WorkloadSelectorSpec describes which workloads should be configured with this proxy configuration. To be valid, WorkloadSelectorSpec must specify Kind and either Name or Selector.
+
+_Appears in:_
+- [AuthProxyWorkloadSpec](#authproxyworkloadspec)
+
+| Field | Description |
+| --- | --- |
+| `selector` _[LabelSelector](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#labelselector-v1-meta)_ | Selector selects resources using labels. See "Label selectors" in the kubernetes docs https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors |
+| `kind` _string_ | Kind specifies what kind of workload Supported kinds: Deployment, StatefulSet, Pod, ReplicaSet,DaemonSet, Job, CronJob Example: "Deployment" "Deployment.v1" or "Deployment.v1.apps". |
+| `namespace` _string_ | Namespace specifies namespace in which to select the resource. Optional, defaults to the namespace of the AuthProxyWorkload resource. All or Wildcard namespaces are not supported. |
+| `name` _string_ | Name specifies the name of the resource to select. |
+
+
+
+

--- a/installer/cloud-sql-proxy-operator.yaml
+++ b/installer/cloud-sql-proxy-operator.yaml
@@ -932,7 +932,7 @@ spec:
                 instances:
                   description: Instances describes the Cloud SQL instances to configure on the proxy container.
                   items:
-                    description: "InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. \n In the minimum recommended configuration, the operator will choose a non-conflicting TCP port and set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. The application can read these values to connect to the database through the proxy. \n ``` \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"portEnvName\":\"MY_DB_SERVER_PORT\" \"hostEnvName\":\"MY_DB_SERVER_HOST\" } \n ``` \n If you want to assign a specific port number for a database, set the `port` field. For example: \n ``` { \"connectionString\":\"my-project:us-central1:my-db-server\", \"port\":5000 } ```"
+                    description: "InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. \n In the minimum recommended configuration, the operator will choose a non-conflicting TCP port and set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. The application can read these values to connect to the database through the proxy. For example: \n `{ \"connectionString\":\"my-project:us-central1:my-db-server\", \"portEnvName\":\"MY_DB_SERVER_PORT\" \"hostEnvName\":\"MY_DB_SERVER_HOST\" }` \n If you want to assign a specific port number for a database, set the `port` field. For example: \n `{ \"connectionString\":\"my-project:us-central1:my-db-server\", \"port\":5000 }`"
                     properties:
                       autoIAMAuthN:
                         description: AutoIAMAuthN (optional) Enables IAM Authentication for this instance. Default value is false.
@@ -973,7 +973,7 @@ spec:
                       description: Name specifies the name of the resource to select.
                       type: string
                     selector:
-                      description: Selector selects resources using labels. See "Label selectors" in the kubernetes docs https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
+                      description: Selector (optional) selects resources using labels. See "Label selectors" in the kubernetes docs https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                       properties:
                         matchExpressions:
                           description: matchExpressions is a list of label selector requirements. The requirements are ANDed.

--- a/installer/cloud-sql-proxy-operator.yaml
+++ b/installer/cloud-sql-proxy-operator.yaml
@@ -48,7 +48,7 @@ spec:
     - name: v1alpha1
       schema:
         openAPIV3Schema:
-          description: AuthProxyWorkload declares how a Cloud SQL Proxy container should be applied to a matching set of workloads, and shows the status of those proxy containers. This is the Schema for the authproxyworkloads API.
+          description: AuthProxyWorkload declares how a Cloud SQL Proxy container should be applied to a matching set of workloads, and shows the status of those proxy containers.
           properties:
             apiVersion:
               description: 'APIVersion defines the versioned schema of this representation of an object. Servers should convert recognized schemas to the latest internal value, and may reject unrecognized values. More info: https://git.k8s.io/community/contributors/devel/sig-architecture/api-conventions.md#resources'
@@ -59,10 +59,10 @@ spec:
             metadata:
               type: object
             spec:
-              description: AuthProxyWorkloadSpec defines the desired state of AuthProxyWorkload
+              description: AuthProxyWorkloadSpec describes where and how to configure the proxy.
               properties:
                 authProxyContainer:
-                  description: AuthProxyContainer describes the resources and config for the Auth Proxy container
+                  description: AuthProxyContainer describes the resources and config for the Auth Proxy container.
                   properties:
                     container:
                       description: Container is debugging parameter that when specified will override the proxy container with a completely custom Container spec.
@@ -930,28 +930,28 @@ spec:
                       type: object
                   type: object
                 instances:
-                  description: Instances lists the Cloud SQL instances to connect
+                  description: Instances describes the Cloud SQL instances to configure on the proxy container.
                   items:
-                    description: "InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. The simplest possible configuration declares just the connection string and the port number or unix socket. \n For example, for a TCP port: \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"port\":5000 } \n or for a unix socket: \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"unixSocketPath\" : \"/mnt/db/my-db-server\" } \n You may allow the operator to choose a non-conflicting TCP port or unix socket instead of explicitly setting the port or socket path. This may be easier to manage when workload needs to connect to many databases. \n For example, for a TCP port: \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"portEnvName\":\"MY_DB_SERVER_PORT\" \"hostEnvName\":\"MY_DB_SERVER_HOST\" } \n will set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. Then, the application can read these values to connect to the database through the proxy. \n or for a unix socket: \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"unixSocketPathEnvName\" : \"MY_DB_SERVER_SOCKET_DIR\" } \n will set environment variables MY_DB_SERVER_SOCKET_DIR with the value of the unix socket path. Then, the application can read this value to connect to the database through the proxy."
+                    description: "InstanceSpec describes the configuration for how the proxy should expose a Cloud SQL database instance to a workload. \n In the minimum recommended configuration, the operator will choose a non-conflicting TCP port and set environment variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port and hostname. The application can read these values to connect to the database through the proxy. \n ``` \n { \"connectionString\":\"my-project:us-central1:my-db-server\", \"portEnvName\":\"MY_DB_SERVER_PORT\" \"hostEnvName\":\"MY_DB_SERVER_HOST\" } \n ``` \n If you want to assign a specific port number for a database, set the `port` field. For example: \n ``` { \"connectionString\":\"my-project:us-central1:my-db-server\", \"port\":5000 } ```"
                     properties:
                       autoIAMAuthN:
-                        description: AutoIAMAuthN Enables IAM Authentication for this instance. Optional, default false.
+                        description: AutoIAMAuthN (optional) Enables IAM Authentication for this instance. Default value is false.
                         type: boolean
                       connectionString:
-                        description: ConnectionString is the Cloud SQL instance.
+                        description: ConnectionString is the connection string for the Cloud SQL Instance in the format `project_id:region:instance_name`
                         type: string
                       hostEnvName:
                         description: HostEnvName The name of the environment variable containing this instances tcp hostname Optional, when set this environment variable will be added to all containers in the workload.
                         type: string
                       port:
-                        description: Port sets the tcp port for this instance. Optional, if not set, a value will be automatically assigned by the operator and set as an environment variable on all containers in the workload named according to PortEnvName. The operator will choose a port so that it does not conflict with other ports on the workload.
+                        description: Port (optional) sets the tcp port for this instance. If not set, a value will be automatically assigned by the operator and set as an environment variable on all containers in the workload named according to PortEnvName. The operator will choose a port so that it does not conflict with other ports on the workload.
                         format: int32
                         type: integer
                       portEnvName:
                         description: PortEnvName is name of the environment variable containing this instance's tcp port. Optional, when set this environment variable will be added to all containers in the workload.
                         type: string
                       privateIP:
-                        description: PrivateIP Enable connection to the Cloud SQL instance's private ip for this instance. Optional, default false.
+                        description: PrivateIP (optional) Enable connection to the Cloud SQL instance's private ip for this instance. Default value is false.
                         type: boolean
                       unixSocketPath:
                         description: UnixSocketPath is the path to the unix socket where the proxy will listen for connnections. This will be mounted to all containers in the pod.
@@ -963,7 +963,7 @@ spec:
                   minItems: 1
                   type: array
                 workloadSelector:
-                  description: Workload selects the workload to
+                  description: Workload selects the workload where the proxy container will be added.
                   properties:
                     kind:
                       description: 'Kind specifies what kind of workload Supported kinds: Deployment, StatefulSet, Pod, ReplicaSet,DaemonSet, Job, CronJob Example: "Deployment" "Deployment.v1" or "Deployment.v1.apps".'

--- a/internal/api/v1alpha1/authproxyworkload_types.go
+++ b/internal/api/v1alpha1/authproxyworkload_types.go
@@ -106,10 +106,10 @@ type AuthProxyWorkloadSpec struct {
 }
 
 // WorkloadSelectorSpec describes which workloads should be configured with this
-// proxy configuration. To be valid, WorkloadSelectorSpec must specify `Kind`
-// and either `Name` or `Selector`.
+// proxy configuration. To be valid, WorkloadSelectorSpec must specify `kind`
+// and either `name` or `selector`.
 type WorkloadSelectorSpec struct {
-	// Selector selects resources using labels. See "Label selectors" in the kubernetes docs
+	// Selector (optional) selects resources using labels. See "Label selectors" in the kubernetes docs
 	// https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
 	//+kubebuilder:validation:Optional
 	Selector *metav1.LabelSelector `json:"selector,omitempty"`
@@ -205,25 +205,19 @@ type TelemetrySpec struct {
 // In the minimum recommended configuration, the operator will choose
 // a non-conflicting TCP port and set environment
 // variables MY_DB_SERVER_PORT MY_DB_SERVER_HOST with the value of the TCP port
-// and hostname. The application can read these values to connect to the
-// database through the proxy.
+// and hostname. The application can read these values to connect to the database
+// through the proxy. For example:
 //
-// ```
-//
-//	{
-//	   "connectionString":"my-project:us-central1:my-db-server",
-//	   "portEnvName":"MY_DB_SERVER_PORT"
-//	   "hostEnvName":"MY_DB_SERVER_HOST"
-//	}
-//
-// ```
+//	`{
+//			   "connectionString":"my-project:us-central1:my-db-server",
+//			   "portEnvName":"MY_DB_SERVER_PORT"
+//			   "hostEnvName":"MY_DB_SERVER_HOST"
+//	}`
 //
 // If you want to assign a specific port number for a database, set the `port`
 // field. For example:
 //
-//	```
-//	{ "connectionString":"my-project:us-central1:my-db-server", "port":5000 }
-//	```
+//	`{ "connectionString":"my-project:us-central1:my-db-server", "port":5000 }`
 type InstanceSpec struct {
 
 	// ConnectionString is the connection string for the Cloud SQL Instance

--- a/internal/api/v1alpha1/groupversion_info.go
+++ b/internal/api/v1alpha1/groupversion_info.go
@@ -12,9 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package v1alpha1 contains API Schema definitions for the cloudsql v1alpha1 API group:
-// the custom resource AuthProxyWorkload version v1alpha1
-// This follows the kubebuilder pattern for defining custom resources.
+// Package v1alpha1 contains the API Schema definitions for the
+// the custom resource AuthProxyWorkload version v1alpha1.
 //
 // +kubebuilder:object:generate=true
 // +groupName=cloudsql.cloud.google.com

--- a/internal/api/v1alpha1/zz_generated.deepcopy.go
+++ b/internal/api/v1alpha1/zz_generated.deepcopy.go
@@ -128,17 +128,17 @@ func (in *AuthProxyWorkloadList) DeepCopyObject() runtime.Object {
 func (in *AuthProxyWorkloadSpec) DeepCopyInto(out *AuthProxyWorkloadSpec) {
 	*out = *in
 	in.Workload.DeepCopyInto(&out.Workload)
-	if in.AuthProxyContainer != nil {
-		in, out := &in.AuthProxyContainer, &out.AuthProxyContainer
-		*out = new(AuthProxyContainerSpec)
-		(*in).DeepCopyInto(*out)
-	}
 	if in.Instances != nil {
 		in, out := &in.Instances, &out.Instances
 		*out = make([]InstanceSpec, len(*in))
 		for i := range *in {
 			(*in)[i].DeepCopyInto(&(*out)[i])
 		}
+	}
+	if in.AuthProxyContainer != nil {
+		in, out := &in.AuthProxyContainer, &out.AuthProxyContainer
+		*out = new(AuthProxyContainerSpec)
+		(*in).DeepCopyInto(*out)
 	}
 }
 

--- a/tools/config-crd-ref-docs.yaml
+++ b/tools/config-crd-ref-docs.yaml
@@ -1,4 +1,4 @@
-# Copyright 2022 Google LLC
+# Copyright 2023 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/tools/config-crd-ref-docs.yaml
+++ b/tools/config-crd-ref-docs.yaml
@@ -29,7 +29,7 @@ processor:
     # skip debug fields on AuthProxyContainerSpec
     - "^Container$"
     - "^SQLAdminAPIEndpoint"
-  useRawDocstring: true
+  useRawDocstring: false
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
   kubernetesVersion: 1.24

--- a/tools/config-crd-ref-docs.yaml
+++ b/tools/config-crd-ref-docs.yaml
@@ -26,6 +26,10 @@ processor:
   ignoreFields:
     - "status$"
     - "TypeMeta$"
+    # skip debug fields on AuthProxyContainerSpec
+    - "^Container$"
+    - "^SQLAdminAPIEndpoint"
+  useRawDocstring: true
 render:
   # Version of Kubernetes to use when generating links to Kubernetes API documentation.
   kubernetesVersion: 1.24

--- a/tools/config-crd-ref-docs.yaml
+++ b/tools/config-crd-ref-docs.yaml
@@ -1,0 +1,31 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+##
+# The configuration file for the crd-ref-docs tool. This tool generates API
+# documentation in markdown for the AuthProxyWorkload CRD from the go source
+# code. See the make target `generate_crd_docs`.
+
+processor:
+  # Ignore lists and status entities. We don't need to include those in the doc
+  ignoreTypes:
+    - "(AuthProxyWorkload)List$"
+    - "(AuthProxyWorkload)Status$"
+  # Ignore status TypeMeta fields
+  ignoreFields:
+    - "status$"
+    - "TypeMeta$"
+render:
+  # Version of Kubernetes to use when generating links to Kubernetes API documentation.
+  kubernetesVersion: 1.24


### PR DESCRIPTION
This will automatically generate API documentation for the AuthProxyWorkload CRD
and put it into the source code at `docs/api.md`. This uses the tool 
[crd-ref-docs](https://github.com/elastic/crd-ref-docs). The api docs are generated
automatically during `make generate` so that the docs commited to the source code 
are always in sync with go source. 

Fixes #165 
