### PR TITLE
fix!: remove Namespace field from AuthProxyWorkloadSelector

### DIFF
--- a/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
+++ b/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
@@ -903,9 +903,6 @@ spec:
                     name:
                       description: Name specifies the name of the resource to select.
                       type: string
-                    namespace:
-                      description: Namespace specifies namespace in which to select the resource. Optional, defaults to the namespace of the AuthProxyWorkload resource. All or Wildcard namespaces are not supported.
-                      type: string
                     selector:
                       description: Selector selects resources using labels. See "Label selectors" in the kubernetes docs https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                       properties:

--- a/installer/cloud-sql-proxy-operator.yaml
+++ b/installer/cloud-sql-proxy-operator.yaml
@@ -921,9 +921,6 @@ spec:
                     name:
                       description: Name specifies the name of the resource to select.
                       type: string
-                    namespace:
-                      description: Namespace specifies namespace in which to select the resource. Optional, defaults to the namespace of the AuthProxyWorkload resource. All or Wildcard namespaces are not supported.
-                      type: string
                     selector:
                       description: Selector selects resources using labels. See "Label selectors" in the kubernetes docs https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#label-selectors
                       properties:

--- a/internal/api/v1alpha1/authproxyworkload_types.go
+++ b/internal/api/v1alpha1/authproxyworkload_types.go
@@ -90,12 +90,6 @@ type WorkloadSelectorSpec struct {
 	//+kubebuilder:validation:Pattern=\w+(\.\w+)*
 	Kind string `json:"kind"`
 
-	// Namespace specifies namespace in which to select the resource.
-	// Optional, defaults to the namespace of the AuthProxyWorkload resource.
-	// All or Wildcard namespaces are not supported.
-	//+kubebuilder:validation:Optional
-	Namespace string `json:"namespace,omitempty"`
-
 	// Name specifies the name of the resource to select.
 	//+kubebuilder:validation:Optional
 	Name string `json:"name,omitempty"`

--- a/internal/controller/authproxyworkload_controller.go
+++ b/internal/controller/authproxyworkload_controller.go
@@ -398,9 +398,6 @@ func newStatus(wl workload.Workload) *cloudsqlapi.WorkloadStatus {
 // listWorkloads produces a list of Workload's that match the WorkloadSelectorSpec
 // in the specified namespace.
 func (r *AuthProxyWorkloadReconciler) listWorkloads(ctx context.Context, workloadSelector cloudsqlapi.WorkloadSelectorSpec, ns string) ([]workload.Workload, error) {
-	if workloadSelector.Namespace != "" {
-		ns = workloadSelector.Namespace
-	}
 
 	if workloadSelector.Name != "" {
 		return r.loadByName(ctx, workloadSelector, ns)

--- a/internal/controller/authproxyworkload_controller_test.go
+++ b/internal/controller/authproxyworkload_controller_test.go
@@ -71,9 +71,8 @@ func TestReconcileDeleted(t *testing.T) {
 	}, "project:region:db")
 	p.Finalizers = []string{finalizerName}
 	p.Spec.Workload = v1alpha1.WorkloadSelectorSpec{
-		Kind:      "Pod",
-		Namespace: "default",
-		Name:      "thing",
+		Kind: "Pod",
+		Name: "thing",
 	}
 
 	cb, err := clientBuilder()
@@ -117,9 +116,8 @@ func TestReconcileState21ByName(t *testing.T) {
 	}, "project:region:db")
 	p.Finalizers = []string{finalizerName}
 	p.Spec.Workload = v1alpha1.WorkloadSelectorSpec{
-		Kind:      "Pod",
-		Name:      "testpod",
-		Namespace: "default",
+		Kind: "Pod",
+		Name: "testpod",
 	}
 
 	err := runReconcileTestcase(p, []client.Object{p}, false, metav1.ConditionTrue, v1alpha1.ReasonNoWorkloadsFound)
@@ -135,8 +133,7 @@ func TestReconcileState21BySelector(t *testing.T) {
 	}, "project:region:db")
 	p.Finalizers = []string{finalizerName}
 	p.Spec.Workload = v1alpha1.WorkloadSelectorSpec{
-		Kind:      "Pod",
-		Namespace: "default",
+		Kind: "Pod",
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{"app": "things"},
 		},
@@ -161,8 +158,7 @@ func TestReconcileState31(t *testing.T) {
 	p.Generation = 1
 	p.Finalizers = []string{finalizerName}
 	p.Spec.Workload = v1alpha1.WorkloadSelectorSpec{
-		Kind:      "Deployment",
-		Namespace: "default",
+		Kind: "Deployment",
 		Selector: &metav1.LabelSelector{
 			MatchLabels: map[string]string{"app": "things"},
 		},


### PR DESCRIPTION
For security, AuthProxyWorkload resources are only allowed to affect workloads running
in the same namespace. This prevents one AuthProxyWorkload in one namespace from affecting
a workload in a different namespace. 

This change removes the WorkloadSelectorSpec.Namespace field and associated code that allowed
cross-namespace workload selection.