### PR TITLE
chore: update to use latest proxy image: 2.0.0

### DIFF
--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -34,7 +34,7 @@ import (
 // package and documented here so that they appear in the godoc. These also
 // need to be documented in the CRD
 const (
-	DefaultProxyImage = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.0.0-preview.4"
+	DefaultProxyImage = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.0.0"
 
 	// DefaultFirstPort is the first port number chose for an instance listener by the
 	// proxy.


### PR DESCRIPTION
The proxy release is complete. Now we must update the operator to deploy the proxy image 2.0.0.