### PR TITLE
feat: Add new terraform project for e2e test resources

### DIFF
--- a/.github/header-checker-lint.yml
+++ b/.github/header-checker-lint.yml
@@ -20,3 +20,4 @@ sourceFileExtensions:
   - 'go'
   - 'yaml'
   - 'yml'
+  - 'tf'

--- a/infra/resources/.gitignore
+++ b/infra/resources/.gitignore
@@ -1,0 +1,6 @@
+.terraform
+terraform.tfstate
+terraform.tfstate.backup
+.terraform.lock*
+secrets.tfvars
+.terraform.tfstate.lock.info

--- a/infra/resources/artifacts.tf
+++ b/infra/resources/artifacts.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/resources/artifacts.tf
+++ b/infra/resources/artifacts.tf
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "google_artifact_registry_repository" "artifact_repo" {
+  location      = var.gcloud_region
+  repository_id = "test${var.environment_name}"
+  description   = "Operator test artifact repo"
+  format        = "DOCKER"
+  project       = var.project_id
+  labels        = local.standard_labels
+}
+
+// example: us-central1-docker.pkg.dev/csql-operator-test/test76e6d646e2caac1c458c
+resource "local_file" "artifact_repo_url" {
+  content = join("/", [
+    "${google_artifact_registry_repository.artifact_repo.location}-docker.pkg.dev",
+    google_artifact_registry_repository.artifact_repo.project,
+  google_artifact_registry_repository.artifact_repo.name])
+  filename = var.gcloud_docker_url_file
+}

--- a/infra/resources/database.tf
+++ b/infra/resources/database.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/resources/database.tf
+++ b/infra/resources/database.tf
@@ -1,0 +1,53 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+resource "random_id" "db_name" {
+  byte_length = 10
+}
+
+resource "random_id" "db_password" {
+  byte_length = 10
+}
+
+# See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
+resource "google_sql_database_instance" "instance" {
+  name             = "inst${random_id.db_name.hex}"
+  project          = var.project_id
+  region           = var.gcloud_region
+  database_version = "POSTGRES_13"
+  settings {
+    tier        = "db-f1-micro"
+    user_labels = local.standard_labels
+  }
+  deletion_protection = "true"
+  root_password       = random_id.db_password.hex
+}
+
+resource "google_sql_database" "db" {
+  name     = "db"
+  instance = google_sql_database_instance.instance.name
+  project  = var.project_id
+}
+
+output "db_root_password" {
+  value = random_id.db_password.hex
+}
+output "db_instance_name" {
+  value = google_sql_database_instance.instance.name
+}
+output "db_database_name" {
+  value = google_sql_database.db.name
+}

--- a/infra/resources/gke_cluster.tf
+++ b/infra/resources/gke_cluster.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/resources/gke_cluster.tf
+++ b/infra/resources/gke_cluster.tf
@@ -1,0 +1,133 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+# From https://github.com/hashicorp/terraform-provider-kubernetes/blob/main/kubernetes/test-infra/gke/main.tf
+
+data "google_client_config" "default" {
+}
+
+data "google_container_engine_versions" "supported" {
+  location       = var.gcloud_zone
+  version_prefix = var.kubernetes_version
+  project        = var.project_id
+}
+
+resource "google_container_cluster" "primary" {
+  project            = var.project_id
+  name               = "operator-test-${var.environment_name}"
+  location           = var.gcloud_zone
+  min_master_version = data.google_container_engine_versions.supported.latest_master_version
+  initial_node_count = 2
+
+  // Alpha features are disabled by default and can be enabled by GKE for a particular GKE control plane version.
+  // Creating an alpha cluster enables all alpha features by default.
+  // Ref: https://cloud.google.com/kubernetes-engine/docs/concepts/feature-gates
+  enable_kubernetes_alpha = var.enable_alpha
+
+  // disalbe the default nodepool and specify node pools as
+  // separate terraform resources. This way if we
+  // change the nodepool config, we don't delete the cluster too
+  remove_default_node_pool = true
+  resource_labels          = local.standard_labels
+
+}
+
+resource "google_container_node_pool" "primary_preemptible_nodes" {
+  name               = "operator-test-nodes-${var.environment_name}"
+  cluster            = google_container_cluster.primary.id
+  initial_node_count = var.workers_count
+  version            = data.google_container_engine_versions.supported.latest_node_version
+  location           = var.gcloud_zone
+
+  autoscaling {
+    max_node_count = 10
+    min_node_count = 2
+  }
+
+  management {
+    auto_repair  = var.enable_alpha ? false : true
+    auto_upgrade = var.enable_alpha ? false : true
+  }
+
+  node_config {
+    preemptible     = true
+    machine_type    = "e2-standard-8"
+    resource_labels = local.standard_labels
+
+    # Google recommends custom service accounts that have cloud-platform scope and permissions granted via IAM Roles.
+    service_account = var.nodepool_serviceaccount_email
+    oauth_scopes = [
+      "https://www.googleapis.com/auth/cloud-platform",
+      "https://www.googleapis.com/auth/compute",
+      "https://www.googleapis.com/auth/devstorage.read_only",
+      "https://www.googleapis.com/auth/logging.write",
+      "https://www.googleapis.com/auth/monitoring",
+      "https://www.googleapis.com/auth/sqlservice.admin",
+    ]
+  }
+}
+
+
+locals {
+  # This is the recommended way to produce a kubeconfig file from
+  # the Google Cloud GKE terraform resource.
+  kubeconfig = {
+    apiVersion = "v1"
+    kind       = "Config"
+    preferences = {
+      colors = true
+    }
+    current-context = google_container_cluster.primary.name
+    contexts = [
+      {
+        name = google_container_cluster.primary.name
+        context = {
+          cluster   = google_container_cluster.primary.name
+          user      = var.nodepool_serviceaccount_email
+          namespace = "default"
+        }
+      }
+    ]
+    clusters = [
+      {
+        name = google_container_cluster.primary.name
+        cluster = {
+          server                     = "https://${google_container_cluster.primary.endpoint}"
+          certificate-authority-data = google_container_cluster.primary.master_auth[0].cluster_ca_certificate
+        }
+      }
+    ]
+    users = [
+      {
+        name = var.nodepool_serviceaccount_email
+        user = {
+          exec = {
+            apiVersion         = "client.authentication.k8s.io/v1beta1"
+            command            = "gke-gcloud-auth-plugin"
+            installHint        = "Install gke-gcloud-auth-plugin for use with kubectl by following https://cloud.google.com/blog/products/containers-kubernetes/kubectl-auth-changes-in-gke"
+            provideClusterInfo = true
+          }
+        }
+      }
+    ]
+  }
+
+}
+
+resource "local_file" "kubeconfig" {
+  content  = yamlencode(local.kubeconfig)
+  filename = var.kubeconfig_path
+}

--- a/infra/resources/main.tf
+++ b/infra/resources/main.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/resources/main.tf
+++ b/infra/resources/main.tf
@@ -1,0 +1,56 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "4.48.0"
+    }
+  }
+}
+
+
+provider "google" {
+}
+
+# Enable gcloud project APIs
+locals {
+  standard_labels = {
+    e2e_test_resource = "true"
+    landscape         = var.environment_name
+  }
+}
+
+##
+# This is how you do an output file containing terraform data for use by
+# a subsequent script.
+
+# First, create the output data structure as a local variable
+locals {
+  output_json = {
+    instance     = google_sql_database_instance.instance.connection_name
+    db           = google_sql_database.db.name
+    rootPassword = random_id.db_password.hex
+    kubeconfig   = var.kubeconfig_path
+  }
+}
+
+# Then write the output data to a local file in json format
+resource "local_file" "testinfra" {
+  content  = jsonencode(local.output_json)
+  filename = var.output_json_path
+}

--- a/infra/resources/vars.tf
+++ b/infra/resources/vars.tf
@@ -1,5 +1,5 @@
 /**
- * Copyright 2022 Google LLC
+ * Copyright 2023 Google LLC
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/infra/resources/vars.tf
+++ b/infra/resources/vars.tf
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2022 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+variable "project_id" {
+  type        = string
+  description = "The gcloud project id"
+}
+
+variable "environment_name" {
+  type        = string
+  description = "The test environment name"
+}
+
+variable "kubeconfig_path" {
+  type        = string
+  description = "The path to save the kubeconfig file"
+}
+variable "output_json_path" {
+  type        = string
+  description = "The path to save test-infra.json file, input for e2e tests"
+}
+variable "gcloud_docker_url_file" {
+  type        = string
+  description = "The path to save the artifact repo url"
+}
+variable "gcloud_bin" {
+  type        = string
+  description = "The absolute path to the gcloud executable"
+}
+
+variable "nodepool_serviceaccount_email" {
+  description = "The service account email address to assign to the nodepool"
+}
+
+variable "kubernetes_version" {
+  default = ""
+}
+
+variable "workers_count" {
+  default = "2"
+}
+
+variable "node_machine_type" {
+  default = "e2-standard-2"
+}
+
+variable "enable_alpha" {
+  default = false
+}
+
+variable "gcloud_zone" {
+  default = "us-central1-c"
+}
+variable "gcloud_region" {
+  default = "us-central1"
+}


### PR DESCRIPTION
This is a copy of the resource provisioning code from `testinfra/*.tf` with this modification: IAM and permissions 
related terraform code is in the `infra/permissions` terraform project. 

Related to #65
