### PR TITLE
test: Add E2E db connection tests for mysql and mssql

### DIFF
--- a/infra/resources/database.tf
+++ b/infra/resources/database.tf
@@ -42,6 +42,63 @@ resource "google_sql_database" "db" {
   project  = var.project_id
 }
 
+# See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
+resource "google_sql_database_instance" "mysql" {
+  name             = "mysql${random_id.db_name.hex}"
+  project          = var.project_id
+  region           = var.gcloud_region
+  database_version = "MYSQL_8_0"
+  settings {
+    tier        = "db-f1-micro"
+    user_labels = local.standard_labels
+  }
+  deletion_protection = "true"
+  root_password       = random_id.db_password.hex
+}
+
+resource "google_sql_database" "db_mysql" {
+  name     = "db"
+  instance = google_sql_database_instance.mysql.name
+  project  = var.project_id
+}
+
+resource "google_sql_user" "mysql_user" {
+  name     = "dbuser"
+  instance = google_sql_database_instance.mysql.name
+  host     = "%"
+  password = random_id.db_password.hex
+  project  = var.project_id
+}
+
+# See versions at https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/sql_database_instance#database_version
+resource "google_sql_database_instance" "mssql" {
+  name             = "mssql${random_id.db_name.hex}"
+  project          = var.project_id
+  region           = var.gcloud_region
+  database_version = "SQLSERVER_2019_EXPRESS"
+  settings {
+    # SQL Server tier format: "db-custom-$CPU-$MEM" where $CPU is the number of
+    # cores and $MEM is memory in MiB
+    tier        = "db-custom-2-3840"
+    user_labels = local.standard_labels
+  }
+  deletion_protection = "true"
+  root_password       = random_id.db_password.hex
+}
+
+resource "google_sql_database" "db_mssql" {
+  name     = "db"
+  instance = google_sql_database_instance.mssql.name
+  project  = var.project_id
+}
+
+resource "google_sql_user" "mssql_user" {
+  name     = "dbuser"
+  instance = google_sql_database_instance.mssql.name
+  password = random_id.db_password.hex
+  project  = var.project_id
+}
+
 output "db_root_password" {
   value = random_id.db_password.hex
 }

--- a/infra/resources/main.tf
+++ b/infra/resources/main.tf
@@ -42,10 +42,27 @@ locals {
 # First, create the output data structure as a local variable
 locals {
   output_json = {
-    instance     = google_sql_database_instance.instance.connection_name
-    db           = google_sql_database.db.name
-    rootPassword = random_id.db_password.hex
-    kubeconfig   = var.kubeconfig_path
+    public = {
+      postgres = {
+        instance     = google_sql_database_instance.instance.connection_name
+        dbName           = google_sql_database.db.name
+        rootUser = "postgres"
+        rootPassword = random_id.db_password.hex
+      }
+      mysql = {
+        instance     = google_sql_database_instance.mysql.connection_name
+        dbName           = google_sql_database.db.name
+        rootUser = google_sql_user.mysql_user.name
+        rootPassword = google_sql_user.mysql_user.password
+      }
+      mssql = {
+        instance     = google_sql_database_instance.mssql.connection_name
+        dbName           = google_sql_database.db.name
+        rootUser = google_sql_user.mssql_user.name
+        rootPassword = google_sql_user.mssql_user.password
+      }
+      kubeconfig   = var.kubeconfig_path
+    }
   }
 }
 

--- a/infra/resources/main.tf
+++ b/infra/resources/main.tf
@@ -45,23 +45,23 @@ locals {
     public = {
       postgres = {
         instance     = google_sql_database_instance.instance.connection_name
-        dbName           = google_sql_database.db.name
-        rootUser = "postgres"
+        dbName       = google_sql_database.db.name
+        rootUser     = "postgres"
         rootPassword = random_id.db_password.hex
       }
       mysql = {
         instance     = google_sql_database_instance.mysql.connection_name
-        dbName           = google_sql_database.db.name
-        rootUser = google_sql_user.mysql_user.name
+        dbName       = google_sql_database.db.name
+        rootUser     = google_sql_user.mysql_user.name
         rootPassword = google_sql_user.mysql_user.password
       }
       mssql = {
         instance     = google_sql_database_instance.mssql.connection_name
-        dbName           = google_sql_database.db.name
-        rootUser = google_sql_user.mssql_user.name
+        dbName       = google_sql_database.db.name
+        rootUser     = google_sql_user.mssql_user.name
         rootPassword = google_sql_user.mssql_user.password
       }
-      kubeconfig   = var.kubeconfig_path
+      kubeconfig = var.kubeconfig_path
     }
   }
 }

--- a/internal/testhelpers/resources.go
+++ b/internal/testhelpers/resources.go
@@ -80,10 +80,11 @@ func BuildSecret(secretName, user, password, dbName string) corev1.Secret {
 // and run a trivial query. It also configures the pod's Liveness probe so that
 // the pod's `Ready` condition is `Ready` when the database can connect.
 func BuildPgPodSpec(mainPodSleep int, appLabel, secretName string) corev1.PodTemplateSpec {
-
-	livenessCmd := "psql --host=$DB_HOST --port=$DB_PORT --username=$DB_USER '--command=select 1' --echo-queries --dbname=$DB_NAME"
-	imageName := "postgres"
-	passEnvVarName := "PGPASSWORD"
+	const (
+		livenessCmd    = "psql --host=$DB_HOST --port=$DB_PORT --username=$DB_USER '--command=select 1' --echo-queries --dbname=$DB_NAME"
+		imageName      = "postgres"
+		passEnvVarName = "PGPASSWORD"
+	)
 
 	return buildConnectPodSpec(mainPodSleep, appLabel, secretName, livenessCmd, passEnvVarName, imageName)
 }
@@ -92,9 +93,11 @@ func BuildPgPodSpec(mainPodSleep int, appLabel, secretName string) corev1.PodTem
 // and run a trivial query. It also configures the pod's Liveness probe so that
 // the pod's `Ready` condition is `Ready` when the database can connect.
 func BuildMysqlPodSpec(mainPodSleep int, appLabel, secretName string) corev1.PodTemplateSpec {
-	livenessCmd := "mysql --host=$DB_HOST --port=$DB_PORT --user=$DB_USER --password=$DB_PASS --database=$DB_NAME '--execute=select now()' "
-	imageName := "mysql"
-	passEnvVarName := "DB_PASS"
+	const (
+		livenessCmd    = "mysql --host=$DB_HOST --port=$DB_PORT --user=$DB_USER --password=$DB_PASS --database=$DB_NAME '--execute=select now()' "
+		imageName      = "mysql"
+		passEnvVarName = "DB_PASS"
+	)
 
 	return buildConnectPodSpec(mainPodSleep, appLabel, secretName, livenessCmd, passEnvVarName, imageName)
 }
@@ -103,9 +106,11 @@ func BuildMysqlPodSpec(mainPodSleep int, appLabel, secretName string) corev1.Pod
 // and run a trivial query. It also configures the pod's Liveness probe so that
 // the pod's `Ready` condition is `Ready` when the database can connect.
 func BuildMSSQLPodSpec(mainPodSleep int, appLabel, secretName string) corev1.PodTemplateSpec {
-	livenessCmd := "/opt/mssql-tools/bin/sqlcmd -S \"tcp:$DB_HOST,$DB_PORT\" -U $DB_USER -P $DB_PASS -Q \"use $DB_NAME ; select 1 ;\""
-	imageName := "mcr.microsoft.com/mssql-tools"
-	passEnvVarName := "DB_PASS"
+	const (
+		livenessCmd    = "/opt/mssql-tools/bin/sqlcmd -S \"tcp:$DB_HOST,$DB_PORT\" -U $DB_USER -P $DB_PASS -Q \"use $DB_NAME ; select 1 ;\""
+		imageName      = "mcr.microsoft.com/mssql-tools"
+		passEnvVarName = "DB_PASS"
+	)
 
 	return buildConnectPodSpec(mainPodSleep, appLabel, secretName, livenessCmd, passEnvVarName, imageName)
 }

--- a/internal/testhelpers/resources.go
+++ b/internal/testhelpers/resources.go
@@ -89,10 +89,10 @@ func BuildPgPodSpec(mainPodSleep int, appLabel, secretName string) corev1.PodTem
 	return buildConnectPodSpec(mainPodSleep, appLabel, secretName, livenessCmd, passEnvVarName, imageName)
 }
 
-// BuildMysqlPodSpec creates a podspec specific to Mysql databases that will connect
+// BuildMySQLPodSpec creates a podspec specific to MySQL databases that will connect
 // and run a trivial query. It also configures the pod's Liveness probe so that
 // the pod's `Ready` condition is `Ready` when the database can connect.
-func BuildMysqlPodSpec(mainPodSleep int, appLabel, secretName string) corev1.PodTemplateSpec {
+func BuildMySQLPodSpec(mainPodSleep int, appLabel, secretName string) corev1.PodTemplateSpec {
 	const (
 		livenessCmd    = "mysql --host=$DB_HOST --port=$DB_PORT --user=$DB_USER --password=$DB_PASS --database=$DB_NAME '--execute=select now()' "
 		imageName      = "mysql"
@@ -102,12 +102,12 @@ func BuildMysqlPodSpec(mainPodSleep int, appLabel, secretName string) corev1.Pod
 	return buildConnectPodSpec(mainPodSleep, appLabel, secretName, livenessCmd, passEnvVarName, imageName)
 }
 
-// BuildMSSQLPodSpec creates a podspec specific to Mysql databases that will connect
+// BuildMSSQLPodSpec creates a podspec specific to MySQL databases that will connect
 // and run a trivial query. It also configures the pod's Liveness probe so that
 // the pod's `Ready` condition is `Ready` when the database can connect.
 func BuildMSSQLPodSpec(mainPodSleep int, appLabel, secretName string) corev1.PodTemplateSpec {
 	const (
-		livenessCmd    = "/opt/mssql-tools/bin/sqlcmd -S \"tcp:$DB_HOST,$DB_PORT\" -U $DB_USER -P $DB_PASS -Q \"use $DB_NAME ; select 1 ;\""
+		livenessCmd    = `/opt/mssql-tools/bin/sqlcmd -S "tcp:$DB_HOST,$DB_PORT" -U $DB_USER -P $DB_PASS -Q "use $DB_NAME ; select 1 ;"`
 		imageName      = "mcr.microsoft.com/mssql-tools"
 		passEnvVarName = "DB_PASS"
 	)
@@ -140,14 +140,14 @@ func buildConnectPodSpec(mainPodSleep int, appLabel, secretName, livenessCmd, pa
 				LivenessProbe: &corev1.Probe{InitialDelaySeconds: 10, PeriodSeconds: 30, FailureThreshold: 3,
 					ProbeHandler: corev1.ProbeHandler{
 						Exec: &corev1.ExecAction{
-							Command: []string{"/bin/sh", "-c", "-e", livenessCmd},
+							Command: []string{"/bin/sh", "-e", "-c", livenessCmd},
 						},
 					},
 				},
 				ReadinessProbe: &corev1.Probe{InitialDelaySeconds: 10, PeriodSeconds: 30, FailureThreshold: 3,
 					ProbeHandler: corev1.ProbeHandler{
 						Exec: &corev1.ExecAction{
-							Command: []string{"/bin/sh", "-c", "-e", livenessCmd},
+							Command: []string{"/bin/sh", "-e", "-c", livenessCmd},
 						},
 					},
 				},

--- a/internal/testhelpers/testcases.go
+++ b/internal/testhelpers/testcases.go
@@ -26,11 +26,14 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
+type DbInstance struct {
+}
 type TestCaseClient struct {
 	Client           client.Client
 	Namespace        string
 	ConnectionString string
 	ProxyImageURL    string
+	DBRootUsername   string
 	DBRootPassword   string
 	DBName           string
 }

--- a/internal/testhelpers/testcases.go
+++ b/internal/testhelpers/testcases.go
@@ -26,8 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-type DbInstance struct {
-}
 type TestCaseClient struct {
 	Client           client.Client
 	Namespace        string

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -45,7 +45,7 @@ func TestMain(m *testing.M) {
 
 func TestCreateAndDeleteResource(t *testing.T) {
 	ctx := testContext()
-	tcc := newTestCaseClient("create")
+	tcc := newPublicPostgresClient("create")
 	res, err := tcc.CreateResource(ctx)
 	if err != nil {
 		t.Error(err)
@@ -105,7 +105,7 @@ func TestProxyAppliedOnNewWorkload(t *testing.T) {
 			ctx := testContext()
 
 			kind := test.o.GetObjectKind().GroupVersionKind().Kind
-			tp := newTestCaseClient("new" + strings.ToLower(kind))
+			tp := newPublicPostgresClient("new" + strings.ToLower(kind))
 
 			err := tp.CreateOrPatchNamespace(ctx)
 			if err != nil {
@@ -204,7 +204,7 @@ func TestProxyAppliedOnExistingWorkload(t *testing.T) {
 			ctx := testContext()
 			kind := test.o.Object().GetObjectKind().GroupVersionKind().Kind
 
-			tp := newTestCaseClient("modify" + strings.ToLower(kind))
+			tp := newPublicPostgresClient("modify" + strings.ToLower(kind))
 
 			err := tp.CreateOrPatchNamespace(ctx)
 			if err != nil {
@@ -300,19 +300,19 @@ func TestPublicDbConnections(t *testing.T) {
 		{
 			name:        "postgres",
 			c:           newPublicPostgresClient("postgresconn"),
-			podTemplate: testhelpers.BuildPgPodSpec(600, appLabel, "db-secret", "DB_USER", "DB_PASS", "DB_NAME"),
+			podTemplate: testhelpers.BuildPgPodSpec(600, appLabel, "db-secret"),
 			allOrAny:    "all",
 		},
 		{
 			name:        "mysql",
 			c:           newPublicMysqlClient("mysqlconn"),
-			podTemplate: testhelpers.BuildMysqlPodSpec(600, appLabel, "db-secret", "DB_USER", "DB_PASS", "DB_NAME"),
+			podTemplate: testhelpers.BuildMysqlPodSpec(600, appLabel, "db-secret"),
 			allOrAny:    "all",
 		},
 		{
 			name:        "mssql",
 			c:           newPublicMssqlClient("mssqlconn"),
-			podTemplate: testhelpers.BuildMSSQLPodSpec(600, appLabel, "db-secret", "DB_USER", "DB_PASS", "DB_NAME"),
+			podTemplate: testhelpers.BuildMSSQLPodSpec(600, appLabel, "db-secret"),
 			allOrAny:    "all",
 		},
 	}
@@ -340,10 +340,7 @@ func TestPublicDbConnections(t *testing.T) {
 
 			key := types.NamespacedName{Name: pwlName, Namespace: tp.Namespace}
 
-			s := testhelpers.BuildSecret("db-secret",
-				"DB_USER", tp.DBRootUsername,
-				"DB_PASS", tp.DBRootPassword,
-				"DB_NAME", tp.DBName)
+			s := testhelpers.BuildSecret("db-secret", tp.DBRootUsername, tp.DBRootPassword, tp.DBName)
 			s.SetNamespace(tp.Namespace)
 			err = tp.Client.Create(ctx, &s)
 			if err != nil {

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -280,7 +280,7 @@ func TestProxyAppliedOnExistingWorkload(t *testing.T) {
 	}
 }
 
-func TestPublicDbConnections(t *testing.T) {
+func TestPublicDBConnections(t *testing.T) {
 	// When running tests during development, set the SKIP_CLEANUP=true envvar so that
 	// the test namespace remains after the test ends. By default, the test
 	// namespace will be deleted when the test exits.
@@ -305,13 +305,13 @@ func TestPublicDbConnections(t *testing.T) {
 		},
 		{
 			name:        "mysql",
-			c:           newPublicMysqlClient("mysqlconn"),
-			podTemplate: testhelpers.BuildMysqlPodSpec(600, appLabel, "db-secret"),
+			c:           newPublicMySQLClient("mysqlconn"),
+			podTemplate: testhelpers.BuildMySQLPodSpec(600, appLabel, "db-secret"),
 			allOrAny:    "all",
 		},
 		{
 			name:        "mssql",
-			c:           newPublicMssqlClient("mssqlconn"),
+			c:           newPublicMSSQLClient("mssqlconn"),
 			podTemplate: testhelpers.BuildMSSQLPodSpec(600, appLabel, "db-secret"),
 			allOrAny:    "all",
 		},

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/testhelpers"
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/workload"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -279,84 +280,115 @@ func TestProxyAppliedOnExistingWorkload(t *testing.T) {
 	}
 }
 
-func TestPostgresConnection(t *testing.T) {
+func TestPublicDbConnections(t *testing.T) {
 	// When running tests during development, set the SKIP_CLEANUP=true envvar so that
 	// the test namespace remains after the test ends. By default, the test
 	// namespace will be deleted when the test exits.
 	skipCleanup := loadValue("SKIP_CLEANUP", "", "false") == "true"
-
-	ctx := testContext()
-
-	tp := newTestCaseClient("pgconnection")
-
-	err := tp.CreateOrPatchNamespace(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-	t.Cleanup(func() {
-		if skipCleanup {
-			return
-		}
-
-		err = tp.DeleteNamespace(ctx)
-		if err != nil {
-			t.Fatal(err)
-		}
-	})
-
 	const (
 		pwlName  = "newss"
-		appLabel = "pgsql"
+		appLabel = "client"
 		kind     = "Deployment"
 	)
-	key := types.NamespacedName{Name: pwlName, Namespace: tp.Namespace}
 
-	s := testhelpers.BuildSecret("db-secret",
-		"DB_USER", "postgres",
-		"DB_PASS", tp.DBRootPassword,
-		"DB_NAME", tp.DBName)
-	s.SetNamespace(tp.Namespace)
-	err = tp.Client.Create(ctx, &s)
-	if err != nil {
-		t.Fatal(err)
+	tests := []struct {
+		name        string
+		c           *testhelpers.TestCaseClient
+		podTemplate corev1.PodTemplateSpec
+		allOrAny    string
+	}{
+		{
+			name:        "postgres",
+			c:           newPublicPostgresClient("postgresconn"),
+			podTemplate: testhelpers.BuildPgPodSpec(600, appLabel, "db-secret", "DB_USER", "DB_PASS", "DB_NAME"),
+			allOrAny:    "all",
+		},
+		{
+			name:        "mysql",
+			c:           newPublicMysqlClient("mysqlconn"),
+			podTemplate: testhelpers.BuildMysqlPodSpec(600, appLabel, "db-secret", "DB_USER", "DB_PASS", "DB_NAME"),
+			allOrAny:    "all",
+		},
+		{
+			name:        "mssql",
+			c:           newPublicMssqlClient("mssqlconn"),
+			podTemplate: testhelpers.BuildMSSQLPodSpec(600, appLabel, "db-secret", "DB_USER", "DB_PASS", "DB_NAME"),
+			allOrAny:    "all",
+		},
+	}
+	for i := range tests {
+		test := tests[i]
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+			ctx := testContext()
+			tp := test.c
+
+			err := tp.CreateOrPatchNamespace(ctx)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Cleanup(func() {
+				if skipCleanup {
+					return
+				}
+
+				err = tp.DeleteNamespace(ctx)
+				if err != nil {
+					t.Fatal(err)
+				}
+			})
+
+			key := types.NamespacedName{Name: pwlName, Namespace: tp.Namespace}
+
+			s := testhelpers.BuildSecret("db-secret",
+				"DB_USER", tp.DBRootUsername,
+				"DB_PASS", tp.DBRootPassword,
+				"DB_NAME", tp.DBName)
+			s.SetNamespace(tp.Namespace)
+			err = tp.Client.Create(ctx, &s)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			wl := &workload.DeploymentWorkload{Deployment: testhelpers.BuildDeployment(types.NamespacedName{}, appLabel)}
+			wl.Deployment.Spec.Template = test.podTemplate
+			t.Log("Creating AuthProxyWorkload")
+
+			err = tp.CreateAuthProxyWorkload(ctx, key, appLabel, tp.ConnectionString, kind)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Log("Waiting for AuthProxyWorkload operator to begin the reconcile loop")
+			_, err = tp.GetAuthProxyWorkloadAfterReconcile(ctx, key)
+			if err != nil {
+				t.Fatal("unable to create AuthProxyWorkload", err)
+			}
+
+			t.Log("Creating ", kind)
+			wl.Object().SetNamespace(tp.Namespace)
+			wl.Object().SetName(pwlName)
+			err = tp.CreateWorkload(ctx, wl.Object())
+			if err != nil {
+				t.Fatal("unable to create ", kind, err)
+			}
+			selector := &metav1.LabelSelector{
+				MatchLabels: map[string]string{"app": appLabel},
+			}
+			t.Log("Checking for container counts", kind)
+			err = tp.ExpectPodContainerCount(ctx, selector, 2, "all")
+			if err != nil {
+				t.Error(err)
+			}
+			t.Log("Checking for ready", kind)
+			err = tp.ExpectPodReady(ctx, selector, "all")
+			if err != nil {
+				t.Error(err)
+			}
+
+			t.Log("Done, OK", kind)
+
+		})
 	}
 
-	wl := &workload.DeploymentWorkload{Deployment: testhelpers.BuildDeployment(types.NamespacedName{}, appLabel)}
-	wl.Deployment.Spec.Template = testhelpers.BuildPgPodSpec(600,
-		appLabel, "db-secret", "DB_USER", "DB_PASS", "DB_NAME")
-	t.Log("Creating AuthProxyWorkload")
-
-	err = tp.CreateAuthProxyWorkload(ctx, key, appLabel, tp.ConnectionString, kind)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	t.Log("Waiting for AuthProxyWorkload operator to begin the reconcile loop")
-	_, err = tp.GetAuthProxyWorkloadAfterReconcile(ctx, key)
-	if err != nil {
-		t.Fatal("unable to create AuthProxyWorkload", err)
-	}
-
-	t.Log("Creating ", kind)
-	wl.Object().SetNamespace(tp.Namespace)
-	wl.Object().SetName(pwlName)
-	err = tp.CreateWorkload(ctx, wl.Object())
-	if err != nil {
-		t.Fatal("unable to create ", kind, err)
-	}
-	selector := &metav1.LabelSelector{
-		MatchLabels: map[string]string{"app": appLabel},
-	}
-	t.Log("Checking for container counts", kind)
-	err = tp.ExpectPodContainerCount(ctx, selector, 2, "all")
-	if err != nil {
-		t.Error(err)
-	}
-	t.Log("Checking for ready", kind)
-	err = tp.ExpectPodReady(ctx, selector, "all")
-	if err != nil {
-		t.Error(err)
-	}
-
-	t.Log("Done, OK", kind)
 }

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -53,40 +53,24 @@ var (
 	operatorURL   string
 )
 
-func newTestCaseClient(ns string) *testhelpers.TestCaseClient {
-	return newPublicPostgresClient(ns)
-}
 func newPublicPostgresClient(ns string) *testhelpers.TestCaseClient {
-	return &testhelpers.TestCaseClient{
-		Client:           c,
-		Namespace:        testhelpers.NewNamespaceName(ns),
-		ConnectionString: infra.Public.Postgres.InstanceConnectionString,
-		DBRootUsername:   infra.Public.Postgres.RootUser,
-		DBRootPassword:   infra.Public.Postgres.RootPassword,
-		DBName:           infra.Public.Postgres.DBName,
-		ProxyImageURL:    proxyImageURL,
-	}
+	return newTestClient(ns, infra.Public.Postgres)
 }
-
 func newPublicMysqlClient(ns string) *testhelpers.TestCaseClient {
-	return &testhelpers.TestCaseClient{
-		Client:           c,
-		Namespace:        testhelpers.NewNamespaceName(ns),
-		ConnectionString: infra.Public.MySQL.InstanceConnectionString,
-		DBRootUsername:   infra.Public.MySQL.RootUser,
-		DBRootPassword:   infra.Public.MySQL.RootPassword,
-		DBName:           infra.Public.MySQL.DBName,
-		ProxyImageURL:    proxyImageURL,
-	}
+	return newTestClient(ns, infra.Public.MySQL)
 }
 func newPublicMssqlClient(ns string) *testhelpers.TestCaseClient {
+	return newTestClient(ns, infra.Public.MSSQL)
+}
+
+func newTestClient(ns string, db testDatabase) *testhelpers.TestCaseClient {
 	return &testhelpers.TestCaseClient{
 		Client:           c,
 		Namespace:        testhelpers.NewNamespaceName(ns),
-		ConnectionString: infra.Public.MSSQL.InstanceConnectionString,
-		DBRootUsername:   infra.Public.MSSQL.RootUser,
-		DBRootPassword:   infra.Public.MSSQL.RootPassword,
-		DBName:           infra.Public.MSSQL.DBName,
+		ConnectionString: db.InstanceConnectionString,
+		DBRootUsername:   db.RootUser,
+		DBRootPassword:   db.RootPassword,
+		DBName:           db.DBName,
 		ProxyImageURL:    proxyImageURL,
 	}
 }

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -56,10 +56,10 @@ var (
 func newPublicPostgresClient(ns string) *testhelpers.TestCaseClient {
 	return newTestClient(ns, infra.Public.Postgres)
 }
-func newPublicMysqlClient(ns string) *testhelpers.TestCaseClient {
+func newPublicMySQLClient(ns string) *testhelpers.TestCaseClient {
 	return newTestClient(ns, infra.Public.MySQL)
 }
-func newPublicMssqlClient(ns string) *testhelpers.TestCaseClient {
+func newPublicMSSQLClient(ns string) *testhelpers.TestCaseClient {
 	return newTestClient(ns, infra.Public.MSSQL)
 }
 

--- a/tests/setup_test.go
+++ b/tests/setup_test.go
@@ -54,12 +54,39 @@ var (
 )
 
 func newTestCaseClient(ns string) *testhelpers.TestCaseClient {
+	return newPublicPostgresClient(ns)
+}
+func newPublicPostgresClient(ns string) *testhelpers.TestCaseClient {
 	return &testhelpers.TestCaseClient{
 		Client:           c,
 		Namespace:        testhelpers.NewNamespaceName(ns),
-		ConnectionString: infra.InstanceConnectionString,
-		DBRootPassword:   infra.RootPassword,
-		DBName:           infra.DB,
+		ConnectionString: infra.Public.Postgres.InstanceConnectionString,
+		DBRootUsername:   infra.Public.Postgres.RootUser,
+		DBRootPassword:   infra.Public.Postgres.RootPassword,
+		DBName:           infra.Public.Postgres.DBName,
+		ProxyImageURL:    proxyImageURL,
+	}
+}
+
+func newPublicMysqlClient(ns string) *testhelpers.TestCaseClient {
+	return &testhelpers.TestCaseClient{
+		Client:           c,
+		Namespace:        testhelpers.NewNamespaceName(ns),
+		ConnectionString: infra.Public.MySQL.InstanceConnectionString,
+		DBRootUsername:   infra.Public.MySQL.RootUser,
+		DBRootPassword:   infra.Public.MySQL.RootPassword,
+		DBName:           infra.Public.MySQL.DBName,
+		ProxyImageURL:    proxyImageURL,
+	}
+}
+func newPublicMssqlClient(ns string) *testhelpers.TestCaseClient {
+	return &testhelpers.TestCaseClient{
+		Client:           c,
+		Namespace:        testhelpers.NewNamespaceName(ns),
+		ConnectionString: infra.Public.MSSQL.InstanceConnectionString,
+		DBRootUsername:   infra.Public.MSSQL.RootUser,
+		DBRootPassword:   infra.Public.MSSQL.RootPassword,
+		DBName:           infra.Public.MSSQL.DBName,
 		ProxyImageURL:    proxyImageURL,
 	}
 }
@@ -104,38 +131,34 @@ func setupTests() (func(), error) {
 	testInfraPath := loadValue("TEST_INFRA_JSON", "", "../bin/testinfra.json")
 	ti, err := loadTestInfra(testInfraPath)
 	if err != nil {
-		kubeconfig := "../../bin/e2e-kubeconfig.yaml"
-		if envKubeConfig, isset := os.LookupEnv("KUBECONFIG"); isset {
-			kubeconfig = envKubeConfig
-		}
-		ti.Kubeconfig = kubeconfig
-		ti.DB = "db"
-		ti.InstanceConnectionString = "proj:region:inst"
-		logger.Info("Test infrastructure not set. Using defaults",
-			"instance", ti.InstanceConnectionString,
-			"db", ti.DB,
-			"kubeconfig", ti.Kubeconfig)
+		return teardownFunc, err
 	}
 	infra = ti
 
+	setupKubernetesClient(ctx, infra.Public)
+
+	return cancelFunc, nil
+}
+
+func setupKubernetesClient(ctx context.Context, ti testEnvironment) error {
 	// Build the kubernetes client
 	config, err := clientcmd.BuildConfigFromFlags("", ti.Kubeconfig)
 	if err != nil {
-		return teardownFunc, fmt.Errorf("unable to build kubernetes client for config %s, %v", ti.Kubeconfig, err)
+		return fmt.Errorf("unable to build kubernetes client for config %s, %v", ti.Kubeconfig, err)
 	}
 	config.RateLimiter = nil
 	k8sClientSet, err = kubernetes.NewForConfig(config)
 	if err != nil {
-		return teardownFunc, fmt.Errorf("unable to setup e2e kubernetes client  %v", err)
+		return fmt.Errorf("unable to setup e2e kubernetes client  %v", err)
 	}
 	s := scheme.Scheme
 	controller.InitScheme(s)
 	c, err = client.New(config, client.Options{Scheme: s})
 	if err != nil {
-		return teardownFunc, fmt.Errorf("Unable to initialize kubernetes client %{v}", err)
+		return fmt.Errorf("Unable to initialize kubernetes client %{v}", err)
 	}
 	if c == nil {
-		return teardownFunc, fmt.Errorf("Kubernetes client was empty after initialization %v", err)
+		return fmt.Errorf("Kubernetes client was empty after initialization %v", err)
 	}
 
 	// Check that the e2e k8s cluster is the operator that was last built from
@@ -143,7 +166,7 @@ func setupTests() (func(), error) {
 	d, err := waitForCorrectOperatorPods(ctx, err)
 
 	if err != nil {
-		return teardownFunc, fmt.Errorf("unable to find manager deployment %v", err)
+		return fmt.Errorf("unable to find manager deployment %v", err)
 	}
 
 	// Start the goroutines to tail the logs from the operator deployment. This
@@ -151,13 +174,13 @@ func setupTests() (func(), error) {
 	// for the developer to follow.
 	podList, err := testhelpers.ListPods(ctx, c, d.GetNamespace(), d.Spec.Selector)
 	if err != nil {
-		return teardownFunc, fmt.Errorf("unable to find manager deployment %v", err)
+		return fmt.Errorf("unable to find manager deployment %v", err)
 	}
 	tailPods(ctx, podList)
 
 	logger.Info("Setup complete. K8s cluster is running.")
 
-	return teardownFunc, nil
+	return nil
 }
 
 func waitForCorrectOperatorPods(ctx context.Context, err error) (*appsv1.Deployment, error) {
@@ -258,11 +281,22 @@ func (l *testSetupLogger) Logf(format string, args ...interface{}) {
 }
 func (l *testSetupLogger) Helper() {}
 
-type testInfra struct {
+type testDatabase struct {
 	InstanceConnectionString string `json:"instance,omitempty"`
-	DB                       string `json:"db,omitempty"`
+	DBName                   string `json:"dbName,omitempty"`
+	RootUser                 string `json:"rootUser,omitempty"`
 	RootPassword             string `json:"rootPassword,omitempty"`
-	Kubeconfig               string `json:"kubeconfig,omitempty"`
+}
+
+type testInfra struct {
+	Public testEnvironment `json:"public"`
+}
+
+type testEnvironment struct {
+	Postgres   testDatabase `json:"postgres,omitempty"`
+	MySQL      testDatabase `json:"mysql,omitempty"`
+	MSSQL      testDatabase `json:"mssql,omitempty"`
+	Kubeconfig string       `json:"kubeconfig,omitempty"`
 }
 
 func loadTestInfra(testInfraJSON string) (testInfra, error) {


### PR DESCRIPTION
Adds terraform code and E2E test cases that connect and run a query on MySQL and MS SQL Server databases. 

Related-to: #52 