### PR TITLE
feat: Automatically trigger pod rollout for appsv1 resources when AuthProxyWorkload changes.

### DIFF
--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,6 +46,16 @@ rules:
       - list
       - watch
   - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - patch
+      - update
+  - apiGroups:
       - batch
     resources:
       - '*'

--- a/installer/cloud-sql-proxy-operator.yaml
+++ b/installer/cloud-sql-proxy-operator.yaml
@@ -1162,6 +1162,16 @@ rules:
       - list
       - watch
   - apiGroups:
+      - apps
+    resources:
+      - daemonsets
+      - deployments
+      - replicasets
+      - statefulsets
+    verbs:
+      - patch
+      - update
+  - apiGroups:
       - batch
     resources:
       - '*'

--- a/internal/api/v1alpha1/authproxyworkload_types.go
+++ b/internal/api/v1alpha1/authproxyworkload_types.go
@@ -45,6 +45,12 @@ const (
 	// when the resource reconcile has finished running.
 	ReasonFinishedReconcile = "FinishedReconcile"
 
+	// ReasonWorkloadNeedsUpdate relates to condition UpToDate, this reason is set
+	// when the resource reconcile found existing workloads related to this
+	// AuthProxyWorkload resource that are not yet configured with an up-to-date
+	// proxy configuration.
+	ReasonWorkloadNeedsUpdate = "WorkloadNeedsUpdate"
+
 	// ReasonNoWorkloadsFound relates to condition UpToDate, this reason is set
 	// when there are no workloads related to this AuthProxyWorkload resource.
 	ReasonNoWorkloadsFound = "NoWorkloadsFound"

--- a/internal/controller/authproxyworkload_controller.go
+++ b/internal/controller/authproxyworkload_controller.go
@@ -353,7 +353,7 @@ func (r *AuthProxyWorkloadReconciler) reconcileResult(ctx context.Context, l log
 // this AuthProxyWorkload resource gets deleted. applyFinalizer is called only
 // once, when the resource first added.
 func (r *AuthProxyWorkloadReconciler) applyFinalizer(
-		ctx context.Context, l logr.Logger, resource *cloudsqlapi.AuthProxyWorkload) (ctrl.Result, error) {
+	ctx context.Context, l logr.Logger, resource *cloudsqlapi.AuthProxyWorkload) (ctrl.Result, error) {
 
 	// The AuthProxyWorkload resource needs a finalizer, so add
 	// the finalizer, exit the reconcile loop and requeue.
@@ -372,7 +372,7 @@ func (r *AuthProxyWorkloadReconciler) applyFinalizer(
 // patchAuthProxyWorkloadStatus uses the PATCH method to incrementally update
 // the AuthProxyWorkload.Status field.
 func (r *AuthProxyWorkloadReconciler) patchAuthProxyWorkloadStatus(
-		ctx context.Context, resource *cloudsqlapi.AuthProxyWorkload, orig *cloudsqlapi.AuthProxyWorkload) error {
+	ctx context.Context, resource *cloudsqlapi.AuthProxyWorkload, orig *cloudsqlapi.AuthProxyWorkload) error {
 	err := r.Client.Status().Patch(ctx, resource, client.MergeFrom(orig))
 	if err != nil {
 		return err
@@ -420,9 +420,9 @@ func replaceStatus(statuses []*cloudsqlapi.WorkloadStatus, updatedStatus *clouds
 	for i := range statuses {
 		s := statuses[i]
 		if s.Name == updatedStatus.Name &&
-				s.Namespace == updatedStatus.Namespace &&
-				s.Kind == updatedStatus.Kind &&
-				s.Version == updatedStatus.Version {
+			s.Namespace == updatedStatus.Namespace &&
+			s.Kind == updatedStatus.Kind &&
+			s.Version == updatedStatus.Version {
 			statuses[i] = updatedStatus
 			updated = true
 		}

--- a/internal/controller/authproxyworkload_controller.go
+++ b/internal/controller/authproxyworkload_controller.go
@@ -292,10 +292,8 @@ func (r *AuthProxyWorkloadReconciler) needsAnnotationUpdate(wl workload.Workload
 
 	// Check if the correct annotation exists
 	an := wl.PodTemplateAnnotations()
-	if an != nil {
-		if an[k] == v {
-			return false
-		}
+	if an != nil && an[k] == v {
+		return false
 	}
 
 	return true
@@ -326,14 +324,11 @@ func (r *AuthProxyWorkloadReconciler) updateAnnotation(wl workload.Workload, res
 // "UpToDate" true and do not requeue.
 func (r *AuthProxyWorkloadReconciler) reconcileResult(ctx context.Context, l logr.Logger, resource, orig *cloudsqlapi.AuthProxyWorkload, reason, message string, upToDate bool) (ctrl.Result, error) {
 
-	var status metav1.ConditionStatus
-	var result ctrl.Result
+	status := metav1.ConditionFalse
+	result := requeueNow
 	if upToDate {
 		status = metav1.ConditionTrue
 		result = ctrl.Result{}
-	} else {
-		status = metav1.ConditionFalse
-		result = requeueNow
 	}
 
 	// Workload updates are complete, update the status
@@ -358,7 +353,7 @@ func (r *AuthProxyWorkloadReconciler) reconcileResult(ctx context.Context, l log
 // this AuthProxyWorkload resource gets deleted. applyFinalizer is called only
 // once, when the resource first added.
 func (r *AuthProxyWorkloadReconciler) applyFinalizer(
-	ctx context.Context, l logr.Logger, resource *cloudsqlapi.AuthProxyWorkload) (ctrl.Result, error) {
+		ctx context.Context, l logr.Logger, resource *cloudsqlapi.AuthProxyWorkload) (ctrl.Result, error) {
 
 	// The AuthProxyWorkload resource needs a finalizer, so add
 	// the finalizer, exit the reconcile loop and requeue.
@@ -377,7 +372,7 @@ func (r *AuthProxyWorkloadReconciler) applyFinalizer(
 // patchAuthProxyWorkloadStatus uses the PATCH method to incrementally update
 // the AuthProxyWorkload.Status field.
 func (r *AuthProxyWorkloadReconciler) patchAuthProxyWorkloadStatus(
-	ctx context.Context, resource *cloudsqlapi.AuthProxyWorkload, orig *cloudsqlapi.AuthProxyWorkload) error {
+		ctx context.Context, resource *cloudsqlapi.AuthProxyWorkload, orig *cloudsqlapi.AuthProxyWorkload) error {
 	err := r.Client.Status().Patch(ctx, resource, client.MergeFrom(orig))
 	if err != nil {
 		return err
@@ -425,9 +420,9 @@ func replaceStatus(statuses []*cloudsqlapi.WorkloadStatus, updatedStatus *clouds
 	for i := range statuses {
 		s := statuses[i]
 		if s.Name == updatedStatus.Name &&
-			s.Namespace == updatedStatus.Namespace &&
-			s.Kind == updatedStatus.Kind &&
-			s.Version == updatedStatus.Version {
+				s.Namespace == updatedStatus.Namespace &&
+				s.Kind == updatedStatus.Kind &&
+				s.Version == updatedStatus.Version {
 			statuses[i] = updatedStatus
 			updated = true
 		}

--- a/internal/controller/authproxyworkload_controller.go
+++ b/internal/controller/authproxyworkload_controller.go
@@ -94,6 +94,7 @@ func (r *AuthProxyWorkloadReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Complete(r)
 }
 
+//+kubebuilder:rbac:groups=apps,resources=deployments;statefulsets;daemonsets;replicasets,verbs=update;patch
 //+kubebuilder:rbac:groups=apps,resources=*,verbs=get;list;watch
 //+kubebuilder:rbac:groups=batch,resources=*,verbs=get;list;watch
 //+kubebuilder:rbac:groups="",resources=*,verbs=get;list;watch
@@ -198,19 +199,24 @@ func (r *AuthProxyWorkloadReconciler) doDelete(ctx context.Context, resource *cl
 // - the condition `UpToDate` status and reason
 //
 // States:
-// |  state  | finalizer| fetch err | len(wl)      | Name                      |
-// |---------|----------|-----------|--------------|---------------------      |
-// | 0       | *        | *         | *            | start                     |
-// | 1.1     | absent   | *         | *            | needs finalizer           |
-// | 1.2     | present  | error     | *            | can't list workloads      |
-// | 2.1     | present  | nil       | == 0         | no workloads to reconcile |
-// | 3.1     | present  | nil       | > 0          | workloads reconciled      |
+// |  state  | finalizer| fetch err | len(wl) | outOfDateCount | Name                                  |
+// |---------|----------|-----------|---------|----------------|---------------------------------------|
+// | 0       | *        | *         | *       |                | start                                 |
+// | 1.1     | absent   | *         | *       |                | needs finalizer                       |
+// | 1.2     | present  | error     | *       |                | can't list workloads                  |
+// | 2.1     | present  | nil       | == 0    |                | no workloads to reconcile             |
+// | 3.1     | present  | nil       | > 0     | > 0 , err      | workload update needed, and failed    |
+// | 3.2     | present  | nil       | > 0     | > 0            | workload update needed, and succeeded |
+// | 3.3     | present  | nil       | > 0     | == 0           | workloads reconciled                  |
 //
-//	start ---x
-//	          \---> 1.1 --> (requeue, goto start)
-//	           \---> 1.2 --> (requeue, goto start)
-//	            \---> 2.1 --> (end)
-//	             \---> 3.1 --> (end)
+//		start ----x
+//		          |---> 1.1 --> (requeue, goto start)
+//		          |---> 1.2 --> (requeue, goto start)
+//		          |---> 2.1 --> (end)
+//		          |
+//	            |---> 3.1 ---> (requeue, goto start)
+//	            |---> 3.2 ---> (requeue, goto start)
+//	            |---> 3.3 ---> (end)
 func (r *AuthProxyWorkloadReconciler) doCreateUpdate(ctx context.Context, l logr.Logger, resource *cloudsqlapi.AuthProxyWorkload) (ctrl.Result, error) {
 	orig := resource.DeepCopy()
 	var err error
@@ -236,36 +242,116 @@ func (r *AuthProxyWorkloadReconciler) doCreateUpdate(ctx context.Context, l logr
 	// State 2.1: When there are no workloads, then mark this as "UpToDate" true,
 	// do not requeue.
 	if len(allWorkloads) == 0 {
-		return r.reconcileResult(ctx, l, resource, orig, cloudsqlapi.ReasonNoWorkloadsFound, "No workload updates needed")
+		return r.reconcileResult(ctx, l, resource, orig, cloudsqlapi.ReasonNoWorkloadsFound, "No workload updates needed", true)
 	}
 
-	// State 3.1: Workload updates are in progress. Check if the workload updates
-	// are complete.
-	//
-	message := fmt.Sprintf("Reconciled %d matching workloads complete", len(allWorkloads))
+	// State 3.*: Workloads already exist. Some may need to be updated to roll out
+	// changes.
+	var outOfDateCount int
+	for _, wl := range allWorkloads {
+		wlChanged := r.needsAnnotationUpdate(wl, resource)
+		if !wlChanged {
+			continue
+		}
 
-	return r.reconcileResult(ctx, l, resource, orig, cloudsqlapi.ReasonFinishedReconcile, message)
+		outOfDateCount++
+		_, err = controllerutil.CreateOrPatch(ctx, r.Client, wl.Object(), func() error {
+			r.updateAnnotation(wl, resource)
+			return nil
+		})
+
+		// State 3.1 Failed to update one of the workloads PodTemplateSpec annotations, requeue.
+		if err != nil {
+			message := fmt.Sprintf("Reconciled %d matching workloads. Error updating workload %v: %v", len(allWorkloads), wl.Object().GetName(), err)
+			return r.reconcileResult(ctx, l, resource, orig, cloudsqlapi.ReasonWorkloadNeedsUpdate, message, false)
+		}
+
+	}
+
+	// State 3.2 Successfully updated all workload PodTemplateSpec annotations, requeue
+	if outOfDateCount > 0 {
+		message := fmt.Sprintf("Reconciled %d matching workloads. %d workloads need updates", len(allWorkloads), outOfDateCount)
+		return r.reconcileResult(ctx, l, resource, orig, cloudsqlapi.ReasonWorkloadNeedsUpdate, message, false)
+	}
+
+	// State 3.3 Workload PodTemplateSpec annotations are all up to date
+	message := fmt.Sprintf("Reconciled %d matching workloads complete", len(allWorkloads))
+	return r.reconcileResult(ctx, l, resource, orig, cloudsqlapi.ReasonFinishedReconcile, message, true)
+}
+
+// needsAnnotationUpdate returns true when the workload was annotated with
+// a different generation of the resource.
+func (r *AuthProxyWorkloadReconciler) needsAnnotationUpdate(wl workload.Workload, resource *cloudsqlapi.AuthProxyWorkload) bool {
+
+	// This workload is not mutable. Ignore it.
+	if _, ok := wl.(workload.WithMutablePodTemplate); !ok {
+		return false
+	}
+
+	k, v := workload.PodAnnotation(resource)
+
+	// Check if the correct annotation exists
+	an := wl.PodTemplateAnnotations()
+	if an != nil {
+		if an[k] == v {
+			return false
+		}
+	}
+
+	return true
+}
+
+// updateAnnotation applies an annotation to the workload for the resource.
+func (r *AuthProxyWorkloadReconciler) updateAnnotation(wl workload.Workload, resource *cloudsqlapi.AuthProxyWorkload) {
+	mpt, ok := wl.(workload.WithMutablePodTemplate)
+
+	// This workload is not mutable. Ignore it.
+	if !ok {
+		return
+	}
+
+	k, v := workload.PodAnnotation(resource)
+
+	// add the annotation if needed...
+	an := wl.PodTemplateAnnotations()
+	if an == nil {
+		an = make(map[string]string)
+	}
+
+	an[k] = v
+	mpt.SetPodTemplateAnnotations(an)
 }
 
 // workloadsReconciled  State 3.1: If workloads are all up to date, mark the condition
 // "UpToDate" true and do not requeue.
-func (r *AuthProxyWorkloadReconciler) reconcileResult(ctx context.Context, l logr.Logger, resource *cloudsqlapi.AuthProxyWorkload, orig *cloudsqlapi.AuthProxyWorkload, reason, message string) (ctrl.Result, error) {
+func (r *AuthProxyWorkloadReconciler) reconcileResult(ctx context.Context, l logr.Logger, resource, orig *cloudsqlapi.AuthProxyWorkload, reason, message string, upToDate bool) (ctrl.Result, error) {
+
+	var status metav1.ConditionStatus
+	var result ctrl.Result
+	if upToDate {
+		status = metav1.ConditionTrue
+		result = ctrl.Result{}
+	} else {
+		status = metav1.ConditionFalse
+		result = requeueNow
+	}
 
 	// Workload updates are complete, update the status
 	resource.Status.Conditions = replaceCondition(resource.Status.Conditions, &metav1.Condition{
 		Type:               cloudsqlapi.ConditionUpToDate,
-		Status:             metav1.ConditionTrue,
+		Status:             status,
 		ObservedGeneration: resource.GetGeneration(),
 		Reason:             reason,
 		Message:            message,
 	})
+
 	err := r.patchAuthProxyWorkloadStatus(ctx, resource, orig)
 	if err != nil {
 		l.Error(err, "Unable to patch status before beginning workloads", "AuthProxyWorkload", resource.GetNamespace()+"/"+resource.GetName())
-		return ctrl.Result{}, err
+		return result, err
 	}
 
-	return ctrl.Result{}, nil
+	return result, nil
 }
 
 // applyFinalizer adds the finalizer so that the operator is notified when

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -17,7 +17,6 @@ package workload
 import (
 	"fmt"
 	"sort"
-	"strconv"
 	"strings"
 
 	corev1 "k8s.io/api/core/v1"
@@ -53,7 +52,7 @@ var l = logf.Log.WithName("internal.workload")
 // on the pod.
 func PodAnnotation(r *cloudsqlapi.AuthProxyWorkload) (string, string) {
 	return fmt.Sprintf("%s/%s", cloudsqlapi.AnnotationPrefix, r.Name),
-		strconv.FormatInt(r.Generation, 10)
+		fmt.Sprintf("%d", r.Generation)
 }
 
 // Updater holds global state used while reconciling workloads.

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -26,7 +26,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
 func TestMain(m *testing.M) {
@@ -253,21 +252,6 @@ func TestProxyAppliedOnExistingWorkload(t *testing.T) {
 			_, err = tp.GetAuthProxyWorkloadAfterReconcile(ctx, key)
 			if err != nil {
 				t.Fatal(err)
-			}
-
-			// if this is an apps/v1 resource with a mutable pod template,
-			// force a rolling update.
-			if wl, ok := test.o.(workload.WithMutablePodTemplate); ok {
-				// patch the workload, add an annotation to the podspec
-				t.Log("Customer updates the workload triggering a rollout")
-				controllerutil.CreateOrPatch(ctx, tp.Client, test.o.Object(), func() error {
-					wl.SetPodTemplateAnnotations(map[string]string{"customer": "updated"})
-					return nil
-				})
-
-				if err != nil {
-					t.Fatal(err)
-				}
 			}
 
 			t.Logf("Wait for %v pods to have 2 containers", test.allOrAny)


### PR DESCRIPTION
Given an AuthProxyWorkload resource that has been applied to StatefulSet, DaemonSet, 
ReplicaSet, and/or Deployment workloads, when that AuthProxyWorkload is updated, the operator 
will add or modify an annotation on the PodTemplateSpec of that workload, causing k8s to
replace the workload's pods following the workload's rollout strategy, thus applying the
AuthProxyWorkload's configuration change.  

Related to #187. 

The code for this feature will be split across a few PRs for clarity. These are the first 4:

1. (This PR) Automatically rollout pod changes on AuthProxyWorkload update.
2. Automatically rollout pod changes on AuthProxyWorkload delete.
3. Add `AutomaticRolloutEnabled` field to the AuthProxyWorkload resource.
4. Update AuthProxyWorkload status conditions to show if a workload has out-of-date pods