### PR TITLE
feat: automatic  changes to workloads when an AuthProxyWorload is deleted

### DIFF
--- a/internal/controller/authproxyworkload_controller.go
+++ b/internal/controller/authproxyworkload_controller.go
@@ -521,7 +521,6 @@ func (r *AuthProxyWorkloadReconciler) loadByLabelSelector(ctx context.Context, w
 func (r *AuthProxyWorkloadReconciler) updateWorkloadAnnotations(ctx context.Context, resource *cloudsqlapi.AuthProxyWorkload, workloads []workload.Workload) (int, error) {
 	var outOfDate int
 	for _, wl := range workloads {
-		// update the workload removing proxy config
 		if r.needsAnnotationUpdate(wl, resource) {
 			outOfDate++
 
@@ -530,7 +529,7 @@ func (r *AuthProxyWorkloadReconciler) updateWorkloadAnnotations(ctx context.Cont
 				return nil
 			})
 
-			// Failed to update one of the workloads PodTemplateSpec annotations, requeue.
+			// Failed to update one of the workloads PodTemplateSpec annotations.
 			if err != nil {
 				return 0, fmt.Errorf("reconciled %d matching workloads. Error removing proxy from workload %v: %v", len(workloads), wl.Object().GetName(), err)
 			}

--- a/internal/controller/authproxyworkload_controller.go
+++ b/internal/controller/authproxyworkload_controller.go
@@ -156,7 +156,7 @@ func (r *AuthProxyWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Re
 			"gen", resource.GetGeneration())
 		r.recentlyDeleted.set(req.NamespacedName, true)
 		// the object has been deleted
-		return r.doDelete(ctx, resource, l)
+		return r.doDelete(ctx, resource)
 	}
 
 	l.Info("Reconcile add/update for AuthProxyWorkload",
@@ -169,7 +169,7 @@ func (r *AuthProxyWorkloadReconciler) Reconcile(ctx context.Context, req ctrl.Re
 
 // doDelete removes our finalizer and updates the related workloads
 // when the reconcile loop receives an AuthProxyWorkload that was deleted.
-func (r *AuthProxyWorkloadReconciler) doDelete(ctx context.Context, resource *cloudsqlapi.AuthProxyWorkload, l logr.Logger) (ctrl.Result, error) {
+func (r *AuthProxyWorkloadReconciler) doDelete(ctx context.Context, resource *cloudsqlapi.AuthProxyWorkload) (ctrl.Result, error) {
 
 	// Mark all related workloads as needing to be updated
 	allWorkloads, err := r.updateWorkloadStatus(ctx, resource)
@@ -177,20 +177,9 @@ func (r *AuthProxyWorkloadReconciler) doDelete(ctx context.Context, resource *cl
 		return requeueNow, err
 	}
 
-	for _, wl := range allWorkloads {
-		// update the workload removing proxy config
-		if r.needsAnnotationUpdate(wl, resource) {
-			_, err = controllerutil.CreateOrPatch(ctx, r.Client, wl.Object(), func() error {
-				r.updateAnnotation(wl, resource)
-				return nil
-			})
-
-			// Failed to update one of the workloads PodTemplateSpec annotations, requeue.
-			if err != nil {
-				return requeueNow, fmt.Errorf("reconciled %d matching workloads. Error removing proxy from workload %v: %v", len(allWorkloads), wl.Object().GetName(), err)
-			}
-			l.Info(fmt.Sprintf("Removed annotation from %v %s", wl.Object().GetObjectKind(), wl.Object().GetName()))
-		}
+	_, err = r.updateWorkloadAnnotations(ctx, resource, allWorkloads)
+	if err != nil {
+		return requeueNow, err
 	}
 
 	// Remove the finalizer so that the object can be fully deleted
@@ -263,25 +252,9 @@ func (r *AuthProxyWorkloadReconciler) doCreateUpdate(ctx context.Context, l logr
 
 	// State 3.*: Workloads already exist. Some may need to be updated to roll out
 	// changes.
-	var outOfDateCount int
-	for _, wl := range allWorkloads {
-		wlChanged := r.needsAnnotationUpdate(wl, resource)
-		if !wlChanged {
-			continue
-		}
-
-		outOfDateCount++
-		_, err = controllerutil.CreateOrPatch(ctx, r.Client, wl.Object(), func() error {
-			r.updateAnnotation(wl, resource)
-			return nil
-		})
-
-		// State 3.1 Failed to update one of the workloads PodTemplateSpec annotations, requeue.
-		if err != nil {
-			message := fmt.Sprintf("Reconciled %d matching workloads. Error updating workload %v: %v", len(allWorkloads), wl.Object().GetName(), err)
-			return r.reconcileResult(ctx, l, resource, orig, cloudsqlapi.ReasonWorkloadNeedsUpdate, message, false)
-		}
-
+	outOfDateCount, err := r.updateWorkloadAnnotations(ctx, resource, allWorkloads)
+	if err != nil {
+		return requeueNow, err
 	}
 
 	// State 3.2 Successfully updated all workload PodTemplateSpec annotations, requeue
@@ -542,5 +515,28 @@ func (r *AuthProxyWorkloadReconciler) loadByLabelSelector(ctx context.Context, w
 		return nil, err
 	}
 	return wl.Workloads(), nil
+
+}
+
+func (r *AuthProxyWorkloadReconciler) updateWorkloadAnnotations(ctx context.Context, resource *cloudsqlapi.AuthProxyWorkload, workloads []workload.Workload) (int, error) {
+	var outOfDate int
+	for _, wl := range workloads {
+		// update the workload removing proxy config
+		if r.needsAnnotationUpdate(wl, resource) {
+			outOfDate++
+
+			_, err := controllerutil.CreateOrPatch(ctx, r.Client, wl.Object(), func() error {
+				r.updateAnnotation(wl, resource)
+				return nil
+			})
+
+			// Failed to update one of the workloads PodTemplateSpec annotations, requeue.
+			if err != nil {
+				return 0, fmt.Errorf("reconciled %d matching workloads. Error removing proxy from workload %v: %v", len(workloads), wl.Object().GetName(), err)
+			}
+		}
+	}
+
+	return outOfDate, nil
 
 }

--- a/internal/testhelpers/resources.go
+++ b/internal/testhelpers/resources.go
@@ -595,7 +595,7 @@ func BuildAuthProxyWorkload(key types.NamespacedName, connectionString string) *
 }
 
 // CreateAuthProxyWorkload creates an AuthProxyWorkload in the kubernetes cluster.
-func (cc *TestCaseClient) CreateAuthProxyWorkload(ctx context.Context, key types.NamespacedName, appLabel string, connectionString string, kind string) error {
+func (cc *TestCaseClient) CreateAuthProxyWorkload(ctx context.Context, key types.NamespacedName, appLabel string, connectionString string, kind string) (*v1alpha1.AuthProxyWorkload, error) {
 	proxy := BuildAuthProxyWorkload(key, connectionString)
 	proxy.Spec.Workload = v1alpha1.WorkloadSelectorSpec{
 		Kind: kind,
@@ -613,9 +613,9 @@ func (cc *TestCaseClient) CreateAuthProxyWorkload(ctx context.Context, key types
 	}
 	err := cc.Client.Create(ctx, proxy)
 	if err != nil {
-		return fmt.Errorf("Unable to create entity %v", err)
+		return nil, fmt.Errorf("Unable to create entity %v", err)
 	}
-	return nil
+	return proxy, nil
 }
 
 // GetConditionStatus finds a condition where Condition.Type == condType and returns

--- a/internal/testhelpers/testcases.go
+++ b/internal/testhelpers/testcases.go
@@ -53,7 +53,7 @@ func (cc *TestCaseClient) CreateResource(ctx context.Context) (*cloudsqlapi.Auth
 		return nil, fmt.Errorf("can't create namespace, %v", err)
 	}
 	key := types.NamespacedName{Name: name, Namespace: ns}
-	err = cc.CreateAuthProxyWorkload(ctx, key, "app", expectedConnStr, "Deployment")
+	_, err = cc.CreateAuthProxyWorkload(ctx, key, "app", expectedConnStr, "Deployment")
 	if err != nil {
 		return nil, fmt.Errorf("unable to create auth proxy workload %v", err)
 	}

--- a/internal/testintegration/integration_test.go
+++ b/internal/testintegration/integration_test.go
@@ -85,7 +85,7 @@ func TestModifiesNewDeployment(t *testing.T) {
 	key := types.NamespacedName{Name: pwlName, Namespace: tcc.Namespace}
 
 	t.Log("Creating AuthProxyWorkload")
-	err = tcc.CreateAuthProxyWorkload(ctx, key, deploymentAppLabel, tcc.ConnectionString, "Deployment")
+	_, err = tcc.CreateAuthProxyWorkload(ctx, key, deploymentAppLabel, tcc.ConnectionString, "Deployment")
 	if err != nil {
 		t.Error(err)
 		return
@@ -158,7 +158,7 @@ func TestModifiesExistingDeployment(t *testing.T) {
 	}
 
 	t.Log("Creating cloud sql instance")
-	err = tcc.CreateAuthProxyWorkload(ctx, pKey, deploymentAppLabel, tcc.ConnectionString, "Deployment")
+	_, err = tcc.CreateAuthProxyWorkload(ctx, pKey, deploymentAppLabel, tcc.ConnectionString, "Deployment")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -48,15 +48,18 @@ const (
 
 var l = logf.Log.WithName("internal.workload")
 
-// PodAnnotation returns the key and value for an annotation on a pod
-// to indicate the specific AuthProxyWorkload resource that was configured
-// on the pod.
+// PodAnnotation returns the annotation (key, value) that should be added to
+// pods that are configured with this AuthProxyWorkload resource. This takes
+// into account whether the AuthProxyWorkload exists or was recently deleted.
 func PodAnnotation(r *cloudsqlapi.AuthProxyWorkload) (string, string) {
+	k := fmt.Sprintf("%s/%s", cloudsqlapi.AnnotationPrefix, r.Name)
 	v := fmt.Sprintf("%d", r.Generation)
+	// if r was deleted, use a different value
 	if r.GetDeletionTimestamp() != nil {
 		v = fmt.Sprintf("%d-deleted-%s", r.Generation, r.GetDeletionTimestamp().Format(time.RFC3339))
 	}
-	return fmt.Sprintf("%s/%s", cloudsqlapi.AnnotationPrefix, r.Name), v
+
+	return k, v
 }
 
 // Updater holds global state used while reconciling workloads.

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"time"
 
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -51,8 +52,11 @@ var l = logf.Log.WithName("internal.workload")
 // to indicate the specific AuthProxyWorkload resource that was configured
 // on the pod.
 func PodAnnotation(r *cloudsqlapi.AuthProxyWorkload) (string, string) {
-	return fmt.Sprintf("%s/%s", cloudsqlapi.AnnotationPrefix, r.Name),
-		fmt.Sprintf("%d", r.Generation)
+	v := fmt.Sprintf("%d", r.Generation)
+	if r.GetDeletionTimestamp() != nil {
+		v = fmt.Sprintf("%d-deleted-%s", r.Generation, r.GetDeletionTimestamp().Format(time.RFC3339))
+	}
+	return fmt.Sprintf("%s/%s", cloudsqlapi.AnnotationPrefix, r.Name), v
 }
 
 // Updater holds global state used while reconciling workloads.


### PR DESCRIPTION
When an AuthProxyWorkload is deleted, automatically update all related workloads that support automatic
rollout: Deployment, StatefulSet, DaemonSet, ReplicaSet.