### PR TITLE
feat: add new field RolloutStrategy control automatic rollout

### DIFF
--- a/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
+++ b/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
@@ -862,6 +862,13 @@ spec:
                           description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
+                    rolloutStrategy:
+                      default: Workload
+                      description: 'RolloutStrategy indicates the strategy to use when rolling out changes to the workloads affected by the results. When this is set to `Workload`, changes to this resource will be automatically applied to a running Deployment, StatefulSet, DaemonSet, or ReplicaSet in accordance with the Strategy set on that workload. When this is set to `None`, the operator will take no action to roll out changes to affected workloads. `Workload` will be used by default if no value is set. See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy'
+                      enum:
+                        - Workload
+                        - None
+                      type: string
                     sqlAdminAPIEndpoint:
                       description: SQLAdminAPIEndpoint is a debugging parameter that when specified will change the Google Cloud api endpoint used by the proxy.
                       type: string

--- a/installer/cloud-sql-proxy-operator.yaml
+++ b/installer/cloud-sql-proxy-operator.yaml
@@ -880,6 +880,13 @@ spec:
                           description: 'Requests describes the minimum amount of compute resources required. If Requests is omitted for a container, it defaults to Limits if that is explicitly specified, otherwise to an implementation-defined value. More info: https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/'
                           type: object
                       type: object
+                    rolloutStrategy:
+                      default: Workload
+                      description: 'RolloutStrategy indicates the strategy to use when rolling out changes to the workloads affected by the results. When this is set to `Workload`, changes to this resource will be automatically applied to a running Deployment, StatefulSet, DaemonSet, or ReplicaSet in accordance with the Strategy set on that workload. When this is set to `None`, the operator will take no action to roll out changes to affected workloads. `Workload` will be used by default if no value is set. See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy'
+                      enum:
+                        - Workload
+                        - None
+                      type: string
                     sqlAdminAPIEndpoint:
                       description: SQLAdminAPIEndpoint is a debugging parameter that when specified will change the Google Cloud api endpoint used by the proxy.
                       type: string

--- a/internal/api/v1alpha1/authproxyworkload_types.go
+++ b/internal/api/v1alpha1/authproxyworkload_types.go
@@ -62,6 +62,18 @@ const (
 	// ReasonUpToDate relates to condition WorkloadUpToDate, this reason is set
 	// when there are no workloads related to this AuthProxyWorkload resource.
 	ReasonUpToDate = "UpToDate"
+
+	// WorkloadStrategy is the RolloutStrategy value that indicates that
+	// when the AuthProxyWorkload is updated or deleted, the changes should be
+	// applied to affected workloads (Deployments, StatefulSets, etc.) following
+	// the Strategy defined by that workload.
+	// See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+	WorkloadStrategy = "Workload"
+
+	// NoneStrategy is the RolloutStrategy value that indicates that the.
+	// when the AuthProxyWorkload is updated or deleted, no action should be taken
+	// by the operator to update the affected workloads.
+	NoneStrategy = "None"
 )
 
 // AuthProxyWorkloadSpec defines the desired state of AuthProxyWorkload
@@ -144,6 +156,19 @@ type AuthProxyContainerSpec struct {
 	// will use the latest known compatible proxy image.
 	//+kubebuilder:validation:Optional
 	Image string `json:"image,omitempty"`
+
+	// RolloutStrategy indicates the strategy to use when rolling out changes to
+	// the workloads affected by the results. When this is set to
+	// `Workload`, changes to this resource will be automatically applied
+	// to a running Deployment, StatefulSet, DaemonSet, or ReplicaSet in
+	// accordance with the Strategy set on that workload. When this is set to
+	// `None`, the operator will take no action to roll out changes to affected
+	// workloads. `Workload` will be used by default if no value is set.
+	// See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+	//+kubebuilder:validation:Optional
+	//+kubebuilder:validation:Enum=Workload;None
+	//+kubebuilder:default=Workload
+	RolloutStrategy string `json:"rolloutStrategy,omitempty"`
 }
 
 // InstanceSpec describes the configuration for how the proxy should expose

--- a/internal/api/v1alpha1/authproxyworkload_webhook.go
+++ b/internal/api/v1alpha1/authproxyworkload_webhook.go
@@ -39,10 +39,9 @@ var _ webhook.Defaulter = &AuthProxyWorkload{}
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *AuthProxyWorkload) Default() {
 	authproxyworkloadlog.Info("default", "name", r.Name)
-	if r.Spec.AuthProxyContainer != nil {
-		if r.Spec.AuthProxyContainer.RolloutStrategy == "" {
-			r.Spec.AuthProxyContainer.RolloutStrategy = WorkloadStrategy
-		}
+	if r.Spec.AuthProxyContainer != nil &&
+			r.Spec.AuthProxyContainer.RolloutStrategy == "" {
+		r.Spec.AuthProxyContainer.RolloutStrategy = WorkloadStrategy
 	}
 }
 

--- a/internal/api/v1alpha1/authproxyworkload_webhook.go
+++ b/internal/api/v1alpha1/authproxyworkload_webhook.go
@@ -40,7 +40,7 @@ var _ webhook.Defaulter = &AuthProxyWorkload{}
 func (r *AuthProxyWorkload) Default() {
 	authproxyworkloadlog.Info("default", "name", r.Name)
 	if r.Spec.AuthProxyContainer != nil &&
-			r.Spec.AuthProxyContainer.RolloutStrategy == "" {
+		r.Spec.AuthProxyContainer.RolloutStrategy == "" {
 		r.Spec.AuthProxyContainer.RolloutStrategy = WorkloadStrategy
 	}
 }

--- a/internal/api/v1alpha1/authproxyworkload_webhook.go
+++ b/internal/api/v1alpha1/authproxyworkload_webhook.go
@@ -39,7 +39,11 @@ var _ webhook.Defaulter = &AuthProxyWorkload{}
 // Default implements webhook.Defaulter so a webhook will be registered for the type
 func (r *AuthProxyWorkload) Default() {
 	authproxyworkloadlog.Info("default", "name", r.Name)
-	// TODO(user): fill in your defaulting logic.
+	if r.Spec.AuthProxyContainer != nil {
+		if r.Spec.AuthProxyContainer.RolloutStrategy == "" {
+			r.Spec.AuthProxyContainer.RolloutStrategy = WorkloadStrategy
+		}
+	}
 }
 
 // TODO(user): change verbs to "verbs=create;update;delete" if you want to enable deletion validation.

--- a/internal/controller/authproxyworkload_controller.go
+++ b/internal/controller/authproxyworkload_controller.go
@@ -276,6 +276,12 @@ func (r *AuthProxyWorkloadReconciler) needsAnnotationUpdate(wl workload.Workload
 		return false
 	}
 
+	// The user has set "None" as the rollout strategy. Ignore it.
+	if resource.Spec.AuthProxyContainer != nil &&
+		resource.Spec.AuthProxyContainer.RolloutStrategy == cloudsqlapi.NoneStrategy {
+		return false
+	}
+
 	k, v := workload.PodAnnotation(resource)
 	// Check if the correct annotation exists
 	an := wl.PodTemplateAnnotations()
@@ -292,6 +298,12 @@ func (r *AuthProxyWorkloadReconciler) updateAnnotation(wl workload.Workload, res
 
 	// This workload is not mutable. Ignore it.
 	if !ok {
+		return
+	}
+
+	// The user has set "None" as the rollout strategy. Ignore it.
+	if resource.Spec.AuthProxyContainer != nil &&
+		resource.Spec.AuthProxyContainer.RolloutStrategy == cloudsqlapi.NoneStrategy {
 		return
 	}
 

--- a/internal/controller/authproxyworkload_controller.go
+++ b/internal/controller/authproxyworkload_controller.go
@@ -276,9 +276,7 @@ func (r *AuthProxyWorkloadReconciler) needsAnnotationUpdate(wl workload.Workload
 		return false
 	}
 
-	// The user has set "None" as the rollout strategy. Ignore it.
-	if resource.Spec.AuthProxyContainer != nil &&
-		resource.Spec.AuthProxyContainer.RolloutStrategy == cloudsqlapi.NoneStrategy {
+	if isRolloutStrategyNone(resource) {
 		return false
 	}
 
@@ -302,8 +300,7 @@ func (r *AuthProxyWorkloadReconciler) updateAnnotation(wl workload.Workload, res
 	}
 
 	// The user has set "None" as the rollout strategy. Ignore it.
-	if resource.Spec.AuthProxyContainer != nil &&
-		resource.Spec.AuthProxyContainer.RolloutStrategy == cloudsqlapi.NoneStrategy {
+	if isRolloutStrategyNone(resource) {
 		return
 	}
 
@@ -317,6 +314,12 @@ func (r *AuthProxyWorkloadReconciler) updateAnnotation(wl workload.Workload, res
 
 	an[k] = v
 	mpt.SetPodTemplateAnnotations(an)
+}
+
+// isRolloutStrategyNone returns true when user has set "None" as the rollout strategy.
+func isRolloutStrategyNone(resource *cloudsqlapi.AuthProxyWorkload) bool {
+	return resource.Spec.AuthProxyContainer != nil &&
+		resource.Spec.AuthProxyContainer.RolloutStrategy == cloudsqlapi.NoneStrategy
 }
 
 // workloadsReconciled  State 3.1: If workloads are all up to date, mark the condition

--- a/internal/controller/authproxyworkload_controller_test.go
+++ b/internal/controller/authproxyworkload_controller_test.go
@@ -215,7 +215,9 @@ func TestReconcileState32RolloutStrategyNone(t *testing.T) {
 			Labels:    map[string]string{labelK: labelV},
 		},
 		Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{}},
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{
+				"annotation": "set",
+			}},
 		}},
 	}
 
@@ -235,7 +237,7 @@ func TestReconcileState32RolloutStrategyNone(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if got, want := len(d.Spec.Template.ObjectMeta.Annotations), 0; got != want {
+	if got, want := len(d.Spec.Template.ObjectMeta.Annotations), 1; got != want {
 		t.Fatalf("got %v annotations, wants %v annotations", got, want)
 	}
 

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -55,7 +55,7 @@ func PodAnnotation(r *cloudsqlapi.AuthProxyWorkload) (string, string) {
 	k := fmt.Sprintf("%s/%s", cloudsqlapi.AnnotationPrefix, r.Name)
 	v := fmt.Sprintf("%d", r.Generation)
 	// if r was deleted, use a different value
-	if r.GetDeletionTimestamp() != nil {
+	if !r.GetDeletionTimestamp().IsZero() {
 		v = fmt.Sprintf("%d-deleted-%s", r.Generation, r.GetDeletionTimestamp().Format(time.RFC3339))
 	}
 


### PR DESCRIPTION
Adds a new field `RolloutStrategy` to the AuthProxyWorkload that will allow users to control how
the operator will roll out changes when an AuthProxyWorkload is updated.

`RolloutStrategy` has two possible values: 

- `Workload` in which the operator will automatically follow the behavior of the Strategy set on the workload.
- `None` in which the operator will not attempt to roll out changes