### PR TITLE
feat: Add support for Unix sockets.

### DIFF
--- a/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
+++ b/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
@@ -935,6 +935,12 @@ spec:
                       privateIP:
                         description: PrivateIP Enable connection to the Cloud SQL instance's private ip for this instance. Optional, default false.
                         type: boolean
+                      unixSocketPath:
+                        description: UnixSocketPath is the path to the unix socket where the proxy will listen for connnections. This will be mounted to all containers in the pod.
+                        type: string
+                      unixSocketPathEnvName:
+                        description: UnixSocketPathEnvName is the environment variable containing the value of UnixSocketPath.
+                        type: string
                     type: object
                   minItems: 1
                   type: array

--- a/docs/authproxyworkload-reference.md
+++ b/docs/authproxyworkload-reference.md
@@ -1,0 +1,33 @@
+# AuthProxyWorkload Reference Documentation
+
+Containing important details about how the AuthProxyWorkload resource can
+be configured.
+
+## Port and PortEnvName
+
+If HostEnvName is set, the operator will set an EnvVar with the value 127.0.0.1.
+If HostEnvName is empty, then no EnvVar is set.
+
+If PortEnvName is set, the operator will set an EnvVar with the port number used
+for that
+instance. If PortEnvName is empty, then no EnvVar is set.
+
+The port used for an instance is computed by `updateState.useInstancePort()`
+which ensures that either Port is used if set, or else a non-conflicting port
+number is chosen by the operator.
+
+At least one of Port and PortEnvName must be set for the configuration to be
+valid. (We need to add this validation to the operator. It will be handled in
+authproxyworkload_webhook.go)
+
+This is how Port and PortEnvName should interact:
+
+| PortEnvName      | Port        | proxy port args | container env  |    
+|------------------|-------------|-----------------|----------------|
+| set to "DB_PORT" | not set     | ?port={next}    | DB_PORT={next} |
+| set to "DB_PORT" | set to 5401 | ?port=5401      | DB_PORT=5401.  |
+| not set          | set to 5401 | ?port=5401      | not set        |
+| not set          | not set     | invalid.        | invalid        |
+
+
+ 

--- a/installer/cloud-sql-proxy-operator.yaml
+++ b/installer/cloud-sql-proxy-operator.yaml
@@ -953,6 +953,12 @@ spec:
                       privateIP:
                         description: PrivateIP Enable connection to the Cloud SQL instance's private ip for this instance. Optional, default false.
                         type: boolean
+                      unixSocketPath:
+                        description: UnixSocketPath is the path to the unix socket where the proxy will listen for connnections. This will be mounted to all containers in the pod.
+                        type: string
+                      unixSocketPathEnvName:
+                        description: UnixSocketPathEnvName is the environment variable containing the value of UnixSocketPath.
+                        type: string
                     type: object
                   minItems: 1
                   type: array

--- a/internal/api/v1alpha1/authproxyworkload_types.go
+++ b/internal/api/v1alpha1/authproxyworkload_types.go
@@ -252,6 +252,16 @@ type InstanceSpec struct {
 	// Optional, when set this environment variable will be added to all containers in the workload.
 	//+kubebuilder:validation:Optional
 	HostEnvName string `json:"hostEnvName,omitempty"`
+
+	// UnixSocketPath is the path to the unix socket where the proxy will listen
+	// for connnections. This will be mounted to all containers in the pod.
+	//+kubebuilder:validation:Optional
+	UnixSocketPath string `json:"unixSocketPath,omitempty"`
+
+	// UnixSocketPathEnvName is the environment variable containing the value of
+	// UnixSocketPath.
+	//+kubebuilder:validation:Optional
+	UnixSocketPathEnvName string `json:"unixSocketPathEnvName,omitempty"`
 }
 
 // AuthProxyWorkloadStatus presents the observed state of AuthProxyWorkload using

--- a/internal/testhelpers/resources.go
+++ b/internal/testhelpers/resources.go
@@ -90,8 +90,8 @@ func BuildPgPodSpec(mainPodSleep int, appLabel, secretName string) corev1.PodTem
 }
 
 // BuildPgUnixPodSpec creates a podspec specific to Postgres databases that will
-// connect via a unix socket and run a trivial. It also configures the pod's
-// Liveness probe so that the pod's `Ready` condition is `Ready` when the
+// connect via a unix socket and run a trivial. It also configures the
+// pod's Liveness probe so that the pod's `Ready` condition is `Ready` when the
 // database can connect.
 func BuildPgUnixPodSpec(mainPodSleep int, appLabel, secretName string) corev1.PodTemplateSpec {
 	const (
@@ -609,24 +609,22 @@ func BuildAuthProxyWorkload(key types.NamespacedName, connectionString string) *
 
 // AddTCPInstance adds a database instance with a tcp connection, setting
 // HostEnvName to "DB_HOST" and PortEnvName to "DB_PORT".
-func AddTCPInstance(p *v1alpha1.AuthProxyWorkload, connectionString string) *v1alpha1.InstanceSpec {
+func AddTCPInstance(p *v1alpha1.AuthProxyWorkload, connectionString string) {
 	p.Spec.Instances = append(p.Spec.Instances, v1alpha1.InstanceSpec{
 		ConnectionString: connectionString,
 		HostEnvName:      "DB_HOST",
 		PortEnvName:      "DB_PORT",
 	})
-	return &p.Spec.Instances[len(p.Spec.Instances)-1]
 }
 
 // AddUnixInstance adds a database instance with a unix socket connection,
 // setting UnixSocketPathEnvName to "DB_PATH".
-func AddUnixInstance(p *v1alpha1.AuthProxyWorkload, connectionString string, path string) *v1alpha1.InstanceSpec {
+func AddUnixInstance(p *v1alpha1.AuthProxyWorkload, connectionString string, path string) {
 	p.Spec.Instances = append(p.Spec.Instances, v1alpha1.InstanceSpec{
 		ConnectionString:      connectionString,
 		UnixSocketPath:        path,
 		UnixSocketPathEnvName: "DB_PATH",
 	})
-	return &p.Spec.Instances[len(p.Spec.Instances)-1]
 }
 
 // NewAuthProxyWorkload creates a new AuthProxyWorkload with the

--- a/internal/testhelpers/resources.go
+++ b/internal/testhelpers/resources.go
@@ -116,6 +116,20 @@ func BuildMySQLPodSpec(mainPodSleep int, appLabel, secretName string) corev1.Pod
 	return buildConnectPodSpec(mainPodSleep, appLabel, secretName, livenessCmd, passEnvVarName, imageName)
 }
 
+// BuildMySQLUnixPodSpec creates a podspec specific to MySQL databases that will
+// connect via a unix socket and run a trivial query. It also configures the
+// pod's Liveness probe so that the pod's `Ready` condition is `Ready` when the
+// database can connect.
+func BuildMySQLUnixPodSpec(mainPodSleep int, appLabel, secretName string) corev1.PodTemplateSpec {
+	const (
+		livenessCmd    = "mysql -S $DB_PATH --user=$DB_USER --password=$DB_PASS --database=$DB_NAME '--execute=select now()' "
+		imageName      = "mysql"
+		passEnvVarName = "DB_PASS"
+	)
+
+	return buildConnectPodSpec(mainPodSleep, appLabel, secretName, livenessCmd, passEnvVarName, imageName)
+}
+
 // BuildMSSQLPodSpec creates a podspec specific to MySQL databases that will connect
 // and run a trivial query. It also configures the pod's Liveness probe so that
 // the pod's `Ready` condition is `Ready` when the database can connect.

--- a/internal/workload/names.go
+++ b/internal/workload/names.go
@@ -47,7 +47,7 @@ func ContainerName(r *cloudsqlapi.AuthProxyWorkload) string {
 // name and the Cloud SQL instance name.
 func VolumeName(r *cloudsqlapi.AuthProxyWorkload, inst *cloudsqlapi.InstanceSpec, mountType string) string {
 	connName := strings.ReplaceAll(strings.ToLower(inst.ConnectionString), ":", "-")
-	return SafePrefixedName(ContainerPrefix, r.GetNamespace()+"-"+r.GetName()+"-"+mountType+"-"+connName)
+	return SafePrefixedName(ContainerPrefix, r.GetName()+"-"+mountType+"-"+connName)
 }
 
 // SafePrefixedName adds a prefix to a name and shortens it while preserving its uniqueness

--- a/internal/workload/names.go
+++ b/internal/workload/names.go
@@ -20,18 +20,11 @@ import (
 	"strings"
 
 	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
-	"k8s.io/apimachinery/pkg/types"
 )
 
 // ContainerPrefix is the name prefix used on containers added to PodSpecs
 // by this operator.
 const ContainerPrefix = "csql-"
-
-// ContainerNameFromNamespacedName generates a valid name for a container, following
-// identical logic to ContainerName
-func ContainerNameFromNamespacedName(r types.NamespacedName) string {
-	return SafePrefixedName(ContainerPrefix, r.Namespace+"-"+r.Name)
-}
 
 // ContainerName generates a valid name for a corev1.Container object that
 // implements this cloudsql instance. Names must be 63 characters or fewer and

--- a/internal/workload/names_test.go
+++ b/internal/workload/names_test.go
@@ -84,7 +84,7 @@ func TestContainerName(t *testing.T) {
 func TestVolumeName(t *testing.T) {
 	csql := authProxyWorkload("hello-world", []v1alpha1.InstanceSpec{{ConnectionString: "proj:inst:db"}})
 	got := workload.VolumeName(csql, &csql.Spec.Instances[0], "temp")
-	want := "csql-default-hello-world-temp-proj-inst-db"
+	want := "csql-hello-world-temp-proj-inst-db"
 	if want != got {
 		t.Errorf("got %v, want %v", got, want)
 	}

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -16,6 +16,7 @@ package workload
 
 import (
 	"fmt"
+	"path"
 	"sort"
 	"strings"
 	"time"
@@ -547,7 +548,7 @@ func (s *updateState) updateContainer(p *cloudsqlapi.AuthProxyWorkload, wl Workl
 				corev1.VolumeMount{
 					Name:      mountName,
 					ReadOnly:  false,
-					MountPath: inst.UnixSocketPath,
+					MountPath: path.Dir(inst.UnixSocketPath),
 				},
 				corev1.Volume{
 					Name:         mountName,

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -748,10 +748,10 @@ func (s *updateState) applyVolumes(ps *corev1.PodSpec) {
 // applyVolumeThings implements complex reconcile logic that is duplicated for both
 // VolumeMount and Volume on containers.
 func applyVolumeThings[T corev1.VolumeMount | corev1.Volume](
-		s *updateState,
-		newVols []T,
-		nameAccessor func(T) string,
-		thingAccessor func(*managedVolume) T) []T {
+	s *updateState,
+	newVols []T,
+	nameAccessor func(T) string,
+	thingAccessor func(*managedVolume) T) []T {
 
 	// add or replace items for all new volume mounts
 	for i := 0; i < len(s.mods.VolumeMounts); i++ {

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -745,8 +745,9 @@ func (s *updateState) applyVolumes(ps *corev1.PodSpec) {
 	ps.Volumes = applyVolumeThings[corev1.Volume](s, ps.Volumes, nameAccessor, thingAccessor)
 }
 
-// applyVolumeThings implements complex reconcile logic that is duplicated for both
-// VolumeMount and Volume on containers.
+// applyVolumeThings modifies a slice of Volume/VolumeMount, to include all the
+// shared volumes for the proxy container's unix sockets. This will replace
+// an existing volume with the same name, or append a new volume to the slice.
 func applyVolumeThings[T corev1.VolumeMount | corev1.Volume](
 	s *updateState,
 	newVols []T,

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -714,6 +714,11 @@ func (s *updateState) addVolumeMount(p *cloudsqlapi.AuthProxyWorkload, is *cloud
 			s.mods.VolumeMounts[i] = vol
 			return
 		}
+		if mount.VolumeMount.MountPath == vol.VolumeMount.MountPath {
+			// avoid adding volume mounts with redundant MountPaths,
+			// just the first one is enough.
+			return
+		}
 	}
 	s.mods.VolumeMounts = append(s.mods.VolumeMounts, vol)
 }
@@ -743,10 +748,10 @@ func (s *updateState) applyVolumes(ps *corev1.PodSpec) {
 // applyVolumeThings implements complex reconcile logic that is duplicated for both
 // VolumeMount and Volume on containers.
 func applyVolumeThings[T corev1.VolumeMount | corev1.Volume](
-	s *updateState,
-	newVols []T,
-	nameAccessor func(T) string,
-	thingAccessor func(*managedVolume) T) []T {
+		s *updateState,
+		newVols []T,
+		nameAccessor func(T) string,
+		thingAccessor func(*managedVolume) T) []T {
 
 	// add or replace items for all new volume mounts
 	for i := 0; i < len(s.mods.VolumeMounts); i++ {

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -702,7 +702,13 @@ func (s *updateState) addHealthCheck(p *cloudsqlapi.AuthProxyWorkload, c *corev1
 }
 
 func (s *updateState) addVolumeMount(p *cloudsqlapi.AuthProxyWorkload, is *cloudsqlapi.InstanceSpec, m corev1.VolumeMount, v corev1.Volume) {
-	key := dbInst(p.Namespace, p.Name, is.ConnectionString)
+	key := proxyInstanceID{
+		AuthProxyWorkload: types.NamespacedName{
+			Namespace: p.Namespace,
+			Name:      p.Name,
+		},
+		ConnectionString: is.ConnectionString,
+	}
 	vol := &managedVolume{
 		Instance:    key,
 		Volume:      v,

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -877,11 +877,14 @@ func TestPodAnnotation(t *testing.T) {
 
 func TestWorkloadUnixVolume(t *testing.T) {
 	var (
-		wantsInstanceName   = "project:server:db"
-		wantsUnixSocketPath = "/mnt/db/server"
-		wantUnixMountDir    = "/mnt/db"
-		wantContainerArgs   = []string{
+		wantsInstanceName    = "project:server:db"
+		wantsInstanceName2   = "project:server:db2"
+		wantsUnixSocketPath  = "/mnt/db/server"
+		wantsUnixSocketPath2 = "/mnt/db/server2"
+		wantUnixMountDir     = "/mnt/db"
+		wantContainerArgs    = []string{
 			fmt.Sprintf("%s?unix-socket-path=%s", wantsInstanceName, wantsUnixSocketPath),
+			fmt.Sprintf("%s?unix-socket-path=%s", wantsInstanceName2, wantsUnixSocketPath2),
 		}
 		wantWorkloadEnv = map[string]string{
 			"DB_SOCKET_PATH": wantsUnixSocketPath,
@@ -900,6 +903,10 @@ func TestWorkloadUnixVolume(t *testing.T) {
 			ConnectionString:      wantsInstanceName,
 			UnixSocketPath:        wantsUnixSocketPath,
 			UnixSocketPathEnvName: "DB_SOCKET_PATH",
+		}, {
+			ConnectionString:      wantsInstanceName2,
+			UnixSocketPath:        wantsUnixSocketPath2,
+			UnixSocketPathEnvName: "DB_SOCKET_PATH2",
 		}}),
 	}
 

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -878,10 +878,10 @@ func TestPodAnnotation(t *testing.T) {
 func TestWorkloadUnixVolume(t *testing.T) {
 	var (
 		wantsInstanceName   = "project:server:db"
-		wantsUnixDir        = "/mnt/db"
-		wantsUnixSocketPath = wantsUnixDir
+		wantsUnixSocketPath = "/mnt/db/server"
+		wantUnixMountDir    = "/mnt/db"
 		wantContainerArgs   = []string{
-			fmt.Sprintf("%s?unix-socket-path=%s", wantsInstanceName, wantsUnixDir),
+			fmt.Sprintf("%s?unix-socket-path=%s", wantsInstanceName, wantsUnixSocketPath),
 		}
 		wantWorkloadEnv = map[string]string{
 			"DB_SOCKET_PATH": wantsUnixSocketPath,
@@ -898,7 +898,7 @@ func TestWorkloadUnixVolume(t *testing.T) {
 	csqls := []*v1alpha1.AuthProxyWorkload{
 		authProxyWorkload("instance1", []v1alpha1.InstanceSpec{{
 			ConnectionString:      wantsInstanceName,
-			UnixSocketPath:        wantsUnixDir,
+			UnixSocketPath:        wantsUnixSocketPath,
 			UnixSocketPathEnvName: "DB_SOCKET_PATH",
 		}}),
 	}
@@ -948,7 +948,7 @@ func TestWorkloadUnixVolume(t *testing.T) {
 	if want, got := 1, len(busyboxContainer.VolumeMounts); want != got {
 		t.Fatalf("got %v, wants %v. Busybox Container.VolumeMounts", got, want)
 	}
-	if want, got := wantsUnixDir, busyboxContainer.VolumeMounts[0].MountPath; want != got {
+	if want, got := wantUnixMountDir, busyboxContainer.VolumeMounts[0].MountPath; want != got {
 		t.Fatalf("got %v, wants %v. Busybox Container.VolumeMounts.MountPath", got, want)
 	}
 	if want, got := wl.Pod.Spec.Volumes[0].Name, busyboxContainer.VolumeMounts[0].Name; want != got {

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -302,6 +302,13 @@ func TestPublicDBConnections(t *testing.T) {
 			allOrAny:    "all",
 		},
 		{
+			name:         "mysql-unix",
+			c:            newPublicMySQLClient("mysqlconnunix"),
+			podTemplate:  testhelpers.BuildMySQLUnixPodSpec(600, appLabel, "db-secret"),
+			allOrAny:     "all",
+			isUnixSocket: true,
+		},
+		{
 			name:        "mssql",
 			c:           newPublicMSSQLClient("mssqlconn"),
 			podTemplate: testhelpers.BuildMSSQLPodSpec(600, appLabel, "db-secret"),

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -387,6 +387,9 @@ func TestPublicDBConnections(t *testing.T) {
 			if err != nil {
 				t.Error(err)
 			}
+
+			// The pods are configured to only be ready when the real database client
+			// successfully executes a simple query on the database.
 			t.Log("Checking for ready", kind)
 			err = tp.ExpectPodReady(ctx, selector, "all")
 			if err != nil {


### PR DESCRIPTION
The operator will configure the pod with a proxy that listens on a unix socket. The operator will mount the
parent directory of each instance's `unixSocketPath` to each container in the pod. When the proxy starts, it 
will create a unix socket for the instance in that mounted directory.

Care should be take to ensure that the parent directory can safely be used across all containers in the pod.
 
Fixes #47 