### PR TITLE
chore: use environment vars to configure global proxy settings

### DIFF
--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -18,7 +18,6 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
-	"strings"
 	"testing"
 	"time"
 
@@ -699,15 +698,13 @@ func TestProxyCLIArgs(t *testing.T) {
 
 			// Test that workload has the right env vars
 			for wantKey, wantValue := range tc.wantWorkloadEnv {
-				containerName := "busybox"
-				if strings.HasPrefix(wantKey, "CSQL_PROXY_") {
-					containerName = csqlContainer.Name
-				}
-				gotEnvVar, err := findEnvVar(wl, containerName, wantKey)
+				gotEnvVar, err := findEnvVar(wl, csqlContainer.Name, wantKey)
 				if err != nil {
 					t.Error(err)
-					logPodSpec(t, wl)
-				} else if gotEnvVar.Value != wantValue {
+					continue
+				}
+
+				if gotEnvVar.Value != wantValue {
 					t.Errorf("got %v, wants %v workload env var %v", gotEnvVar, wantValue, wantKey)
 				}
 			}

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -517,6 +518,7 @@ func TestProxyCLIArgs(t *testing.T) {
 		proxySpec            v1alpha1.AuthProxyWorkloadSpec
 		wantProxyArgContains []string
 		wantErrorCodes       []string
+		wantWorkloadEnv      map[string]string
 	}
 	wantTrue := true
 	wantFalse := false
@@ -533,12 +535,12 @@ func TestProxyCLIArgs(t *testing.T) {
 					PortEnvName:      "DB_PORT",
 				}},
 			},
-			wantProxyArgContains: []string{
-				"--structured-logs",
-				"--health-check",
-				fmt.Sprintf("--http-port=%d", workload.DefaultHealthCheckPort),
-				"--http-address=0.0.0.0",
-				"--user-agent=cloud-sql-proxy-operator/dev",
+			wantWorkloadEnv: map[string]string{
+				"CSQL_PROXY_STRUCTURED_LOGS": "true",
+				"CSQL_PROXY_HEALTH_CHECK":    "true",
+				"CSQL_PROXY_HTTP_PORT":       fmt.Sprintf("%d", workload.DefaultHealthCheckPort),
+				"CSQL_PROXY_HTTP_ADDRESS":    "0.0.0.0",
+				"CSQL_PROXY_USER_AGENT":      "cloud-sql-proxy-operator/dev",
 			},
 		},
 		{
@@ -622,25 +624,6 @@ func TestProxyCLIArgs(t *testing.T) {
 				fmt.Sprintf("hello:world:two?port=%d&private-ip=false", workload.DefaultFirstPort+1)},
 		},
 		{
-			desc: "global flags",
-			proxySpec: v1alpha1.AuthProxyWorkloadSpec{
-				AuthProxyContainer: &v1alpha1.AuthProxyContainerSpec{
-					SQLAdminAPIEndpoint: "https://example.com",
-					MaxConnections:      ptr(int64(10)),
-					MaxSigtermDelay:     ptr(int64(20)),
-				},
-				Instances: []v1alpha1.InstanceSpec{{
-					ConnectionString: "hello:world:one",
-				}},
-			},
-			wantProxyArgContains: []string{
-				fmt.Sprintf("hello:world:one?port=%d", workload.DefaultFirstPort),
-				"--sqladmin-api-endpoint=https://example.com",
-				"--max-connections=10",
-				"--max-sigterm-delay=20",
-			},
-		},
-		{
 			desc: "port conflict with other instance causes error",
 			proxySpec: v1alpha1.AuthProxyWorkloadSpec{
 				Instances: []v1alpha1.InstanceSpec{{
@@ -713,6 +696,21 @@ func TestProxyCLIArgs(t *testing.T) {
 
 			// test that port cli args are set correctly
 			assertContainerArgsContains(t, csqlContainer.Args, tc.wantProxyArgContains)
+
+			// Test that workload has the right env vars
+			for wantKey, wantValue := range tc.wantWorkloadEnv {
+				containerName := "busybox"
+				if strings.HasPrefix(wantKey, "CSQL_PROXY_") {
+					containerName = csqlContainer.Name
+				}
+				gotEnvVar, err := findEnvVar(wl, containerName, wantKey)
+				if err != nil {
+					t.Error(err)
+					logPodSpec(t, wl)
+				} else if gotEnvVar.Value != wantValue {
+					t.Errorf("got %v, wants %v workload env var %v", gotEnvVar, wantValue, wantKey)
+				}
+			}
 
 		})
 	}


### PR DESCRIPTION
Use environment variables instead of CLI flags to configure the global proxy settings
for proxy containers. 