### PR TITLE
chore: Bundle third party licenses into docker image.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ testbin/*
 
 # Ignore downloaded 3rd party license files
 ThirdPartyLicenses
+

--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ testbin/*
 
 # Ignore secrets for the build
 /build.env
+
+# Ignore downloaded 3rd party license files
+ThirdPartyLicenses

--- a/Dockerfile-operator
+++ b/Dockerfile-operator
@@ -39,4 +39,6 @@ ARG TARGETARCH
 WORKDIR /
 USER 65532:65532
 COPY --from=build --chown=nonroot "/work/bin/manager" "/manager"
+COPY "./ThirdPartyLicenses" "/ThirdPartyLicenses"
+COPY "./LICENSE" "/LICENSE"
 ENTRYPOINT ["/manager"]


### PR DESCRIPTION
The OSS community and licenses require us to include a copy of the license for linked open-source licenses
in our distribution. The docker image is our only binary artifact. This bundles a copy of the license for this project, 
and all linked dependencies into the docker image.