### PR TITLE
feat: Validate AuthProxyWorkload updates to prevent changes to the workload selector.

### DIFF
--- a/internal/api/v1alpha1/authproxyworkload_test.go
+++ b/internal/api/v1alpha1/authproxyworkload_test.go
@@ -84,6 +84,63 @@ func TestAuthProxyWorkload_ValidateCreate(t *testing.T) {
 			},
 			wantValid: true,
 		},
+		{
+			desc: "update fail, kind changed",
+			spec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{Kind: "Deployment", Name: "webapp"},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "proj:region:db2",
+					PortEnvName:      "DB_PORT",
+				}},
+			},
+			oldSpec: &cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{Kind: "StatefulSet", Name: "webapp"},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "proj:region:db1",
+					PortEnvName:      "DB_PORT",
+				}},
+			},
+			wantCreateValid: true,
+			wantUpdateValid: false,
+		},
+		{
+			desc: "update fail, name changed",
+			spec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{Kind: "Deployment", Name: "webapp"},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "proj:region:db2",
+					PortEnvName:      "DB_PORT",
+				}},
+			},
+			oldSpec: &cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{Kind: "Deployment", Name: "other"},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "proj:region:db1",
+					PortEnvName:      "DB_PORT",
+				}},
+			},
+			wantCreateValid: true,
+			wantUpdateValid: false,
+		},
+		{
+			desc: "update fail, selector changed",
+			spec: cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{Kind: "Deployment", Selector: &v1.LabelSelector{MatchLabels: map[string]string{"app": "sample"}}},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "proj:region:db2",
+					PortEnvName:      "DB_PORT",
+				}},
+			},
+			oldSpec: &cloudsqlapi.AuthProxyWorkloadSpec{
+				Workload: cloudsqlapi.WorkloadSelectorSpec{Kind: "Deployment", Selector: &v1.LabelSelector{MatchLabels: map[string]string{"app": "other"}}},
+				Instances: []cloudsqlapi.InstanceSpec{{
+					ConnectionString: "proj:region:db1",
+					PortEnvName:      "DB_PORT",
+				}},
+			},
+			wantCreateValid: true,
+			wantUpdateValid: false,
+		},
 	}
 
 	for _, tc := range data {


### PR DESCRIPTION
We do not allow a user to change the selector of an AuthProxyWorkload, as it will require the operator to do
too much bookkeeping. We can keep our code clean and simple if the operator assumes that the
workload selected for a proxy configuration never changes. 

Related to #36 