### PR TITLE
chore: bump go version in release job

### DIFF
--- a/.github/workflows/release-please-updates.yaml
+++ b/.github/workflows/release-please-updates.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19'
+          go-version: '1.20'
       - name: Checkout code
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Release-As: 0.3.0
