### PR TITLE
test: Make the default image slightly more configurable for better testing

### DIFF
--- a/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
+++ b/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
@@ -1155,9 +1155,6 @@ spec:
                       - type
                     type: object
                   type: array
-                deployedProxyImage:
-                  description: DefaultProxyImage This field holds default proxy image last deployed on proxy containers for this workload. This field is empty when the customer explicitly sets the proxy image in AuthProxyContainerSpec.Image.
-                  type: string
               type: object
           type: object
       served: true

--- a/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
+++ b/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
@@ -863,7 +863,7 @@ spec:
                         - name
                       type: object
                     image:
-                      description: Image is the URL to the proxy image. Optional, by default the operator will use the latest known compatible proxy image.
+                      description: "Image is the URL to the proxy image. Optional, by default the operator will use the latest Cloud SQL Auth Proxy version as of the release of the operator. \n The operator ensures that all workloads configured with the default proxy image are upgraded automatically to use to the latest released proxy image. \n When the customer upgrades the operator, the operator upgrades all workloads using the default proxy image to the latest proxy image. The change to the proxy container image is applied in accordance with the RolloutStrategy."
                       type: string
                     maxConnections:
                       description: MaxConnections limits the number of connections. Default value is no limit. This sets the proxy container's CLI argument `--max-connections`
@@ -1155,6 +1155,9 @@ spec:
                       - type
                     type: object
                   type: array
+                deployedProxyImage:
+                  description: DefaultProxyImage This field holds default proxy image last deployed on proxy containers for this workload. This field is empty when the customer explicitly sets the proxy image in AuthProxyContainerSpec.Image.
+                  type: string
               type: object
           type: object
       served: true

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,7 +48,9 @@ _Appears in:_
 | `maxConnections` _integer_ | MaxConnections limits the number of connections. Default value is no limit. This sets the proxy container's CLI argument `--max-connections` |
 | `maxSigtermDelay` _integer_ | MaxSigtermDelay is the maximum number of seconds to wait for connections to close after receiving a TERM signal. This sets the proxy container's CLI argument `--max-sigterm-delay` and configures `terminationGracePeriodSeconds` on the workload's PodSpec. |
 | `sqlAdminAPIEndpoint` _string_ | SQLAdminAPIEndpoint is a debugging parameter that when specified will change the Google Cloud api endpoint used by the proxy. |
-| `image` _string_ | Image is the URL to the proxy image. Optional, by default the operator will use the latest known compatible proxy image. |
+| `image` _string_ | Image is the URL to the proxy image. Optional, by default the operator will use the latest Cloud SQL Auth Proxy version as of the release of the operator. 
+ The operator ensures that all workloads configured with the default proxy image are upgraded automatically to use to the latest released proxy image. 
+ When the customer upgrades the operator, the operator upgrades all workloads using the default proxy image to the latest proxy image. The change to the proxy container image is applied in accordance with the RolloutStrategy. |
 | `rolloutStrategy` _string_ | RolloutStrategy indicates the strategy to use when rolling out changes to the workloads affected by the results. When this is set to `Workload`, changes to this resource will be automatically applied to a running Deployment, StatefulSet, DaemonSet, or ReplicaSet in accordance with the Strategy set on that workload. When this is set to `None`, the operator will take no action to roll out changes to affected workloads. `Workload` will be used by default if no value is set. See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
 
 

--- a/installer/cloud-sql-proxy-operator.yaml
+++ b/installer/cloud-sql-proxy-operator.yaml
@@ -881,7 +881,7 @@ spec:
                         - name
                       type: object
                     image:
-                      description: Image is the URL to the proxy image. Optional, by default the operator will use the latest known compatible proxy image.
+                      description: "Image is the URL to the proxy image. Optional, by default the operator will use the latest Cloud SQL Auth Proxy version as of the release of the operator. \n The operator ensures that all workloads configured with the default proxy image are upgraded automatically to use to the latest released proxy image. \n When the customer upgrades the operator, the operator upgrades all workloads using the default proxy image to the latest proxy image. The change to the proxy container image is applied in accordance with the RolloutStrategy."
                       type: string
                     maxConnections:
                       description: MaxConnections limits the number of connections. Default value is no limit. This sets the proxy container's CLI argument `--max-connections`
@@ -1173,6 +1173,9 @@ spec:
                       - type
                     type: object
                   type: array
+                deployedProxyImage:
+                  description: DefaultProxyImage This field holds default proxy image last deployed on proxy containers for this workload. This field is empty when the customer explicitly sets the proxy image in AuthProxyContainerSpec.Image.
+                  type: string
               type: object
           type: object
       served: true

--- a/installer/cloud-sql-proxy-operator.yaml
+++ b/installer/cloud-sql-proxy-operator.yaml
@@ -1173,9 +1173,6 @@ spec:
                       - type
                     type: object
                   type: array
-                deployedProxyImage:
-                  description: DefaultProxyImage This field holds default proxy image last deployed on proxy containers for this workload. This field is empty when the customer explicitly sets the proxy image in AuthProxyContainerSpec.Image.
-                  type: string
               type: object
           type: object
       served: true

--- a/internal/api/v1alpha1/authproxyworkload_types.go
+++ b/internal/api/v1alpha1/authproxyworkload_types.go
@@ -357,11 +357,6 @@ type AuthProxyWorkloadStatus struct {
 	// WorkloadStatus presents the observed status of individual workloads that match
 	// this AuthProxyWorkload resource.
 	WorkloadStatus []*WorkloadStatus `json:"WorkloadStatus,omitempty"`
-
-	// DefaultProxyImage This field holds default proxy image last deployed on
-	// proxy containers for this workload. This field is empty when the customer
-	// explicitly sets the proxy image in AuthProxyContainerSpec.Image.
-	DefaultProxyImage string `json:"deployedProxyImage,omitempty"`
 }
 
 // WorkloadStatus presents the status for how this AuthProxyWorkload resource

--- a/internal/api/v1alpha1/authproxyworkload_types.go
+++ b/internal/api/v1alpha1/authproxyworkload_types.go
@@ -179,7 +179,17 @@ type AuthProxyContainerSpec struct {
 	SQLAdminAPIEndpoint string `json:"sqlAdminAPIEndpoint,omitempty"`
 
 	// Image is the URL to the proxy image. Optional, by default the operator
-	// will use the latest known compatible proxy image.
+	// will use the latest Cloud SQL Auth Proxy version as of the release of the
+	// operator.
+	//
+	// The operator ensures that all workloads configured with the default proxy
+	// image are upgraded automatically to use to the latest released proxy image.
+	//
+	// When the customer upgrades the operator, the operator upgrades all
+	// workloads using the default proxy image to the latest proxy image. The
+	// change to the proxy container image is applied in accordance with
+	// the RolloutStrategy.
+	//
 	//+kubebuilder:validation:Optional
 	Image string `json:"image,omitempty"`
 
@@ -337,7 +347,6 @@ type InstanceSpec struct {
 // AuthProxyWorkloadStatus presents the observed state of AuthProxyWorkload using
 // standard Kubernetes Conditions.
 type AuthProxyWorkloadStatus struct {
-
 	// Conditions show the overall status of the AuthProxyWorkload resource on all
 	// matching workloads.
 	//
@@ -348,6 +357,11 @@ type AuthProxyWorkloadStatus struct {
 	// WorkloadStatus presents the observed status of individual workloads that match
 	// this AuthProxyWorkload resource.
 	WorkloadStatus []*WorkloadStatus `json:"WorkloadStatus,omitempty"`
+
+	// DefaultProxyImage This field holds default proxy image last deployed on
+	// proxy containers for this workload. This field is empty when the customer
+	// explicitly sets the proxy image in AuthProxyContainerSpec.Image.
+	DefaultProxyImage string `json:"deployedProxyImage,omitempty"`
 }
 
 // WorkloadStatus presents the status for how this AuthProxyWorkload resource

--- a/internal/controller/authproxyworkload_controller.go
+++ b/internal/controller/authproxyworkload_controller.go
@@ -280,7 +280,7 @@ func (r *AuthProxyWorkloadReconciler) needsAnnotationUpdate(wl workload.Workload
 		return false
 	}
 
-	k, v := workload.PodAnnotation(resource)
+	k, v := r.updater.PodAnnotation(resource)
 	// Check if the correct annotation exists
 	an := wl.PodTemplateAnnotations()
 	if an != nil && an[k] == v {
@@ -304,7 +304,7 @@ func (r *AuthProxyWorkloadReconciler) updateAnnotation(wl workload.Workload, res
 		return
 	}
 
-	k, v := workload.PodAnnotation(resource)
+	k, v := r.updater.PodAnnotation(resource)
 
 	// add the annotation if needed...
 	an := wl.PodTemplateAnnotations()

--- a/internal/controller/authproxyworkload_controller_test.go
+++ b/internal/controller/authproxyworkload_controller_test.go
@@ -78,7 +78,7 @@ func TestReconcileDeleted(t *testing.T) {
 		t.Error(err) // shouldn't ever happen
 	}
 	c := cb.WithObjects(p).Build()
-	r, req, ctx := reconciler(p, c)
+	r, req, ctx := reconciler(p, c, workload.DefaultProxyImage)
 
 	c.Delete(ctx, p)
 	if err != nil {
@@ -261,7 +261,7 @@ func TestReconcileState33(t *testing.T) {
 	addSelectorWorkload(p, "Deployment", labelK, labelV)
 
 	// mimic a pod that was updated by the webhook
-	reqName := v1alpha1.AnnotationPrefix + "/" + p.Name
+	reqName, reqVal := workload.PodAnnotation(p, workload.DefaultProxyImage)
 	pod := &appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "thing",
@@ -269,7 +269,7 @@ func TestReconcileState33(t *testing.T) {
 			Labels:    map[string]string{labelK: labelV},
 		},
 		Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{
-			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{reqName: "1"}},
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{reqName: reqVal}},
 		}},
 	}
 
@@ -293,7 +293,7 @@ func TestReconcileDeleteUpdatesWorkload(t *testing.T) {
 	addFinalizers(resource)
 	addSelectorWorkload(resource, "Deployment", labelK, labelV)
 
-	k, v := workload.PodAnnotation(resource)
+	k, v := workload.PodAnnotation(resource, workload.DefaultProxyImage)
 
 	// mimic a deployment that was updated by the webhook
 	deployment := &appsv1.Deployment{
@@ -313,7 +313,7 @@ func TestReconcileDeleteUpdatesWorkload(t *testing.T) {
 		t.Error(err) // shouldn't ever happen
 	}
 	c := cb.WithObjects(resource, deployment).Build()
-	r, req, ctx := reconciler(resource, c)
+	r, req, ctx := reconciler(resource, c, workload.DefaultProxyImage)
 
 	// Delete the resource
 	c.Delete(ctx, resource)
@@ -360,6 +360,73 @@ func TestReconcileDeleteUpdatesWorkload(t *testing.T) {
 
 }
 
+func TestWorkloadUpdatedAfterDefaultProxyImageChanged(t *testing.T) {
+	const (
+		labelK = "app"
+		labelV = "things"
+	)
+	resource := testhelpers.BuildAuthProxyWorkload(types.NamespacedName{
+		Namespace: "default",
+		Name:      "test",
+	}, "project:region:db")
+	resource.Generation = 1
+	addFinalizers(resource)
+	addSelectorWorkload(resource, "Deployment", labelK, labelV)
+
+	// Deployment annotation should be updated to this after reconcile:
+	_, wantV := workload.PodAnnotation(resource, "gcr.io/cloud-sql-connectors/cloud-sql-proxy:999.9.9")
+
+	// mimic a deployment that was updated by the webhook
+	// annotate the deployment with the default image
+	k, v := workload.PodAnnotation(resource, "gcr.io/cloud-sql-connectors/cloud-sql-proxy:1.1.1")
+	deployment := &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "thing",
+			Namespace: "default",
+			Labels:    map[string]string{labelK: labelV},
+		},
+		Spec: appsv1.DeploymentSpec{Template: corev1.PodTemplateSpec{
+			ObjectMeta: metav1.ObjectMeta{Annotations: map[string]string{k: v}},
+		}},
+	}
+
+	// Build a client with the resource and deployment
+	cb, err := clientBuilder()
+	if err != nil {
+		t.Error(err) // shouldn't ever happen
+	}
+	c := cb.WithObjects(resource, deployment).Build()
+
+	// Create a reconciler with the default proxy image at a different version
+	r, req, ctx := reconciler(resource, c, "gcr.io/cloud-sql-connectors/cloud-sql-proxy:999.9.9")
+
+	// Run Reconcile on the resource
+	res, err := r.Reconcile(ctx, req)
+	if err != nil {
+		t.Error(err)
+	}
+
+	if !res.Requeue {
+		t.Errorf("got %v, want %v for requeue", res.Requeue, true)
+	}
+
+	// Fetch the deployment and make sure the annotations show the
+	// deleted resource.
+	d := &appsv1.Deployment{}
+	err = c.Get(ctx, types.NamespacedName{
+		Namespace: deployment.GetNamespace(),
+		Name:      deployment.GetName(),
+	}, d)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got := d.Spec.Template.ObjectMeta.Annotations[k]; got != wantV {
+		t.Fatalf("got %v, wants annotation value %v", got, wantV)
+	}
+
+}
+
 func runReconcileTestcase(p *v1alpha1.AuthProxyWorkload, clientObjects []client.Object, wantRequeue bool, wantStatus metav1.ConditionStatus, wantReason string) (client.WithWatch, context.Context, error) {
 	cb, err := clientBuilder()
 	if err != nil {
@@ -368,7 +435,7 @@ func runReconcileTestcase(p *v1alpha1.AuthProxyWorkload, clientObjects []client.
 
 	c := cb.WithObjects(clientObjects...).Build()
 
-	r, req, ctx := reconciler(p, c)
+	r, req, ctx := reconciler(p, c, workload.DefaultProxyImage)
 	res, err := r.Reconcile(ctx, req)
 	if err != nil {
 		return nil, nil, err
@@ -417,12 +484,12 @@ func clientBuilder() (*fake.ClientBuilder, error) {
 
 }
 
-func reconciler(p *v1alpha1.AuthProxyWorkload, cb client.Client) (*AuthProxyWorkloadReconciler, ctrl.Request, context.Context) {
+func reconciler(p *v1alpha1.AuthProxyWorkload, cb client.Client, defaultProxyImage string) (*AuthProxyWorkloadReconciler, ctrl.Request, context.Context) {
 	ctx := log.IntoContext(context.Background(), logger)
 	r := &AuthProxyWorkloadReconciler{
 		Client:          cb,
 		recentlyDeleted: &recentlyDeletedCache{},
-		updater:         workload.NewUpdater("cloud-sql-proxy-operator/dev"),
+		updater:         workload.NewUpdater("cloud-sql-proxy-operator/dev", defaultProxyImage),
 	}
 	req := ctrl.Request{
 		NamespacedName: types.NamespacedName{

--- a/internal/controller/proxy_image_upgrade.go
+++ b/internal/controller/proxy_image_upgrade.go
@@ -1,0 +1,70 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+type upgradeDefaultProxyOnStartup struct {
+	c client.Client
+}
+
+func (c *upgradeDefaultProxyOnStartup) findProxyNeedingUpdate(ctx context.Context) error {
+
+	l := &v1alpha1.AuthProxyWorkloadList{}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			err := c.c.List(ctx, l, client.Continue(l.Continue))
+			if err != nil {
+				return fmt.Errorf("can't list AuthProxyWorkload on startup, %v", err)
+			}
+
+			for _, p := range l.Items {
+				useDefaultImage := p.Spec.AuthProxyContainer == nil || p.Spec.AuthProxyContainer.Image == ""
+
+				if !useDefaultImage {
+					continue
+				}
+
+				// If an APW has a default image, then perform an "update" on it so that
+				// the reconcile function runs and triggers the appropriate rolling updates.
+				log.FromContext(ctx).Info(fmt.Sprintf("Upgrading workload default images for %s/%s", p.Namespace, p.Namespace))
+				err = c.c.Update(ctx, &p)
+			}
+			if l.Continue == "" {
+				return nil
+			}
+		}
+	}
+
+}
+
+func (c *upgradeDefaultProxyOnStartup) Start(ctx context.Context) error {
+	go c.findProxyNeedingUpdate(ctx)
+	return nil
+}
+
+func (c *upgradeDefaultProxyOnStartup) NeedLeaderElection() bool {
+	return true
+}

--- a/internal/testintegration/integration_test.go
+++ b/internal/testintegration/integration_test.go
@@ -18,12 +18,17 @@
 package testintegration_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/testhelpers"
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/testintegration"
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/workload"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestMain(m *testing.M) {
@@ -47,7 +52,6 @@ func newTestCaseClient(name string) *testhelpers.TestCaseClient {
 		Client:           testintegration.Client,
 		Namespace:        testhelpers.NewNamespaceName(name),
 		ConnectionString: "region:project:inst",
-		ProxyImageURL:    "proxy-image:latest",
 	}
 }
 
@@ -178,26 +182,128 @@ func TestModifiesExistingDeployment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Then we simulate the deployment pods being replaced
-	err = tcc.Client.Delete(ctx, rs1)
+	err = recreatePodsAfterDeploymentUpdate(ctx, tcc, d, rs1, pods)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	for i := 0; i < len(pods); i++ {
-		err = tcc.Client.Delete(ctx, pods[i])
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-	_, _, err = tcc.CreateDeploymentReplicaSetAndPods(ctx, d)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// and check for 2 containers
 	err = tcc.ExpectPodContainerCount(ctx, d.Spec.Selector, 2, "all")
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestUpdateWorkloadContainerWhenDefaultProxyImageChanges(t *testing.T) {
+	ctx := testintegration.TestContext()
+	tcc := newTestCaseClient("modifynew")
+
+	err := tcc.CreateOrPatchNamespace(ctx)
+	if err != nil {
+		t.Fatalf("can't create namespace, %v", err)
+	}
+
+	const (
+		pwlName            = "newdeploy"
+		deploymentAppLabel = "busybox"
+	)
+	key := types.NamespacedName{Name: pwlName, Namespace: tcc.Namespace}
+
+	t.Log("Creating AuthProxyWorkload")
+	p, err := tcc.CreateAuthProxyWorkload(ctx, key, deploymentAppLabel, tcc.ConnectionString, "Deployment")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	t.Log("Waiting for AuthProxyWorkload operator to begin the reconcile loop")
+	_, err = tcc.GetAuthProxyWorkloadAfterReconcile(ctx, key)
+	if err != nil {
+		t.Error("unable to create AuthProxyWorkload", err)
+		return
+	}
+
+	t.Log("Creating deployment")
+	d := testhelpers.BuildDeployment(key, deploymentAppLabel)
+	err = tcc.CreateWorkload(ctx, d)
+	if err != nil {
+		t.Error("unable to create deployment", err)
+		return
+	}
+
+	t.Log("Creating deployment replicas")
+	rs, pl, err := tcc.CreateDeploymentReplicaSetAndPods(ctx, d)
+	if err != nil {
+		t.Error("unable to create pods", err)
+		return
+	}
+
+	// Check that proxy container was added to pods
+	err = tcc.ExpectPodContainerCount(ctx, d.Spec.Selector, 2, "all")
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check that the pods have the expected default proxy image
+	pods, err := testhelpers.ListPods(ctx, tcc.Client, tcc.Namespace, d.Spec.Selector)
+	for _, p := range pods.Items {
+		if got, want := p.Spec.Containers[1].Image, workload.DefaultProxyImage; got != want {
+			t.Errorf("got %v, want %v image before operator upgrade", got, want)
+		}
+	}
+
+	// Restart the manager with a new default proxy image
+	const newDefault = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:999.9.9"
+	err = testintegration.RestartManager(newDefault)
+	if err != nil {
+		t.Fatal("can't restart container", err)
+	}
+
+	// Get the related deployment. Make sure that annotations were
+	// set on the pod template
+	ud := &appsv1.Deployment{}
+	err = tcc.Client.Get(ctx, client.ObjectKeyFromObject(d), ud)
+	if err != nil {
+		t.Error(err)
+	}
+	wantK, wantV := workload.PodAnnotation(p, newDefault)
+	gotV := ud.Spec.Template.Annotations[wantK]
+	if gotV != wantV {
+		t.Errorf("Got %s, want %s for podspec annotation", gotV, wantV)
+	}
+
+	// Recreate the ReplicaSet and Pods as would happen when the deployment
+	// PodTemplate changed.
+	err = recreatePodsAfterDeploymentUpdate(ctx, tcc, d, rs, pl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the new pods have the new default proxy image
+	pods, err = testhelpers.ListPods(ctx, tcc.Client, tcc.Namespace, d.Spec.Selector)
+	for _, p := range pods.Items {
+		if got, want := p.Spec.Containers[1].Image, newDefault; got != want {
+			t.Errorf("got %v, want %v image before operator upgrade", got, want)
+		}
+	}
+
+}
+
+func recreatePodsAfterDeploymentUpdate(ctx context.Context, tcc *testhelpers.TestCaseClient, d *appsv1.Deployment, rs1 *appsv1.ReplicaSet, pods []*corev1.Pod) error {
+	// Then we simulate the deployment pods being replaced
+	err := tcc.Client.Delete(ctx, rs1)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(pods); i++ {
+		err = tcc.Client.Delete(ctx, pods[i])
+		if err != nil {
+			return err
+		}
+	}
+	_, _, err = tcc.CreateDeploymentReplicaSetAndPods(ctx, d)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -139,7 +139,7 @@ func TestUpdatePodWorkload(t *testing.T) {
 		wantContainerName       = "csql-default-" + wantsName
 		wantsInstanceName       = "project:server:db"
 		wantsInstanceArg        = fmt.Sprintf("%s?port=%d", wantsInstanceName, wantsPort)
-		u                       = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u                       = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 	var err error
 
@@ -194,7 +194,7 @@ func TestUpdateWorkloadFixedPort(t *testing.T) {
 			"DB_HOST": "127.0.0.1",
 			"DB_PORT": strconv.Itoa(int(wantsPort)),
 		}
-		u = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod
@@ -262,7 +262,7 @@ func TestWorkloadNoPortSet(t *testing.T) {
 			"DB_PORT": strconv.Itoa(int(wantsPort)),
 		}
 	)
-	u := workload.NewUpdater("cloud-sql-proxy-operator/dev")
+	u := workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 
 	// Create a pod
 	wl := podWorkload()
@@ -320,7 +320,7 @@ func TestContainerImageChanged(t *testing.T) {
 	var (
 		wantsInstanceName = "project:server:db"
 		wantImage         = "custom-image:latest"
-		u                 = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u                 = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod
@@ -362,7 +362,7 @@ func TestContainerImageEmpty(t *testing.T) {
 	var (
 		wantsInstanceName = "project:server:db"
 		wantImage         = workload.DefaultProxyImage
-		u                 = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u                 = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 	// Create a AuthProxyWorkload that matches the deployment
 
@@ -421,7 +421,7 @@ func TestContainerReplaced(t *testing.T) {
 		wantContainer     = &corev1.Container{
 			Name: "sample", Image: "debian:latest", Command: []string{"/bin/bash"},
 		}
-		u = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod
@@ -475,7 +475,7 @@ func TestResourcesFromSpec(t *testing.T) {
 			},
 		}
 
-		u = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod
@@ -725,7 +725,7 @@ func TestProxyCLIArgs(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
-			u := workload.NewUpdater("cloud-sql-proxy-operator/dev")
+			u := workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 
 			// Create a pod
 			wl := &workload.PodWorkload{Pod: &corev1.Pod{
@@ -857,11 +857,11 @@ func TestPodTemplateAnnotations(t *testing.T) {
 		now = metav1.Now()
 
 		wantAnnotations = map[string]string{
-			"cloudsql.cloud.google.com/instance1": "1",
-			"cloudsql.cloud.google.com/instance2": "2",
+			"cloudsql.cloud.google.com/instance1": "1," + workload.DefaultProxyImage,
+			"cloudsql.cloud.google.com/instance2": "2," + workload.DefaultProxyImage,
 		}
 
-		u = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod
@@ -908,17 +908,17 @@ func TestPodAnnotation(t *testing.T) {
 			name:  "instance1",
 			r:     server,
 			wantK: "cloudsql.cloud.google.com/instance1",
-			wantV: "1",
+			wantV: fmt.Sprintf("1,%s", workload.DefaultProxyImage),
 		}, {
 			name:  "instance2",
 			r:     deletedServer,
 			wantK: "cloudsql.cloud.google.com/instance2",
-			wantV: fmt.Sprintf("2-deleted-%s", now.Format(time.RFC3339)),
+			wantV: fmt.Sprintf("2-deleted-%s,%s", now.Format(time.RFC3339), workload.DefaultProxyImage),
 		},
 	}
 
 	for _, tc := range testcases {
-		gotK, gotV := workload.PodAnnotation(tc.r)
+		gotK, gotV := workload.PodAnnotation(tc.r, workload.DefaultProxyImage)
 		if tc.wantK != gotK {
 			t.Errorf("got %v, want %v for key", gotK, tc.wantK)
 		}
@@ -942,7 +942,7 @@ func TestWorkloadUnixVolume(t *testing.T) {
 		wantWorkloadEnv = map[string]string{
 			"DB_SOCKET_PATH": wantsUnixSocketPath,
 		}
-		u = workload.NewUpdater("authproxyworkload/dev")
+		u = workload.NewUpdater("authproxyworkload/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"runtime"
 
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/controller"
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/workload"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -87,7 +89,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = controller.SetupManagers(mgr, userAgent)
+	err = controller.SetupManagers(mgr, userAgent, workload.DefaultProxyImage)
 	if err != nil {
 		setupLog.Error(err, "unable to set up the controllers")
 		os.Exit(1)


### PR DESCRIPTION
Make it easier to test that when the default image hardcoded into the operator changes, workloads using the old default
will be identified and reconfigured properly.

(There is another PR coming after this one which will automatically reconfigure all AuthProxyWorkload resources as the on operator startup.)

Related to #87 