### PR TITLE
feat: When the operator's default proxy image changes, workload containers should be updated.

### DIFF
--- a/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
+++ b/config/crd/bases/cloudsql.cloud.google.com_authproxyworkloads.yaml
@@ -863,7 +863,7 @@ spec:
                         - name
                       type: object
                     image:
-                      description: Image is the URL to the proxy image. Optional, by default the operator will use the latest known compatible proxy image.
+                      description: "Image is the URL to the proxy image. Optional, by default the operator will use the latest Cloud SQL Auth Proxy version as of the release of the operator. \n The operator ensures that all workloads configured with the default proxy image are upgraded automatically to use to the latest released proxy image. \n When the customer upgrades the operator, the operator upgrades all workloads using the default proxy image to the latest proxy image. The change to the proxy container image is applied in accordance with the RolloutStrategy."
                       type: string
                     maxConnections:
                       description: MaxConnections limits the number of connections. Default value is no limit. This sets the proxy container's CLI argument `--max-connections`

--- a/docs/api.md
+++ b/docs/api.md
@@ -48,7 +48,9 @@ _Appears in:_
 | `maxConnections` _integer_ | MaxConnections limits the number of connections. Default value is no limit. This sets the proxy container's CLI argument `--max-connections` |
 | `maxSigtermDelay` _integer_ | MaxSigtermDelay is the maximum number of seconds to wait for connections to close after receiving a TERM signal. This sets the proxy container's CLI argument `--max-sigterm-delay` and configures `terminationGracePeriodSeconds` on the workload's PodSpec. |
 | `sqlAdminAPIEndpoint` _string_ | SQLAdminAPIEndpoint is a debugging parameter that when specified will change the Google Cloud api endpoint used by the proxy. |
-| `image` _string_ | Image is the URL to the proxy image. Optional, by default the operator will use the latest known compatible proxy image. |
+| `image` _string_ | Image is the URL to the proxy image. Optional, by default the operator will use the latest Cloud SQL Auth Proxy version as of the release of the operator. 
+ The operator ensures that all workloads configured with the default proxy image are upgraded automatically to use to the latest released proxy image. 
+ When the customer upgrades the operator, the operator upgrades all workloads using the default proxy image to the latest proxy image. The change to the proxy container image is applied in accordance with the RolloutStrategy. |
 | `rolloutStrategy` _string_ | RolloutStrategy indicates the strategy to use when rolling out changes to the workloads affected by the results. When this is set to `Workload`, changes to this resource will be automatically applied to a running Deployment, StatefulSet, DaemonSet, or ReplicaSet in accordance with the Strategy set on that workload. When this is set to `None`, the operator will take no action to roll out changes to affected workloads. `Workload` will be used by default if no value is set. See: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy |
 
 

--- a/installer/cloud-sql-proxy-operator.yaml
+++ b/installer/cloud-sql-proxy-operator.yaml
@@ -881,7 +881,7 @@ spec:
                         - name
                       type: object
                     image:
-                      description: Image is the URL to the proxy image. Optional, by default the operator will use the latest known compatible proxy image.
+                      description: "Image is the URL to the proxy image. Optional, by default the operator will use the latest Cloud SQL Auth Proxy version as of the release of the operator. \n The operator ensures that all workloads configured with the default proxy image are upgraded automatically to use to the latest released proxy image. \n When the customer upgrades the operator, the operator upgrades all workloads using the default proxy image to the latest proxy image. The change to the proxy container image is applied in accordance with the RolloutStrategy."
                       type: string
                     maxConnections:
                       description: MaxConnections limits the number of connections. Default value is no limit. This sets the proxy container's CLI argument `--max-connections`

--- a/internal/api/v1alpha1/authproxyworkload_types.go
+++ b/internal/api/v1alpha1/authproxyworkload_types.go
@@ -179,7 +179,17 @@ type AuthProxyContainerSpec struct {
 	SQLAdminAPIEndpoint string `json:"sqlAdminAPIEndpoint,omitempty"`
 
 	// Image is the URL to the proxy image. Optional, by default the operator
-	// will use the latest known compatible proxy image.
+	// will use the latest Cloud SQL Auth Proxy version as of the release of the
+	// operator.
+	//
+	// The operator ensures that all workloads configured with the default proxy
+	// image are upgraded automatically to use to the latest released proxy image.
+	//
+	// When the customer upgrades the operator, the operator upgrades all
+	// workloads using the default proxy image to the latest proxy image. The
+	// change to the proxy container image is applied in accordance with
+	// the RolloutStrategy.
+	//
 	//+kubebuilder:validation:Optional
 	Image string `json:"image,omitempty"`
 
@@ -337,7 +347,6 @@ type InstanceSpec struct {
 // AuthProxyWorkloadStatus presents the observed state of AuthProxyWorkload using
 // standard Kubernetes Conditions.
 type AuthProxyWorkloadStatus struct {
-
 	// Conditions show the overall status of the AuthProxyWorkload resource on all
 	// matching workloads.
 	//

--- a/internal/controller/authproxyworkload_controller.go
+++ b/internal/controller/authproxyworkload_controller.go
@@ -280,7 +280,7 @@ func (r *AuthProxyWorkloadReconciler) needsAnnotationUpdate(wl workload.Workload
 		return false
 	}
 
-	k, v := workload.PodAnnotation(resource)
+	k, v := r.updater.PodAnnotation(resource)
 	// Check if the correct annotation exists
 	an := wl.PodTemplateAnnotations()
 	if an != nil && an[k] == v {
@@ -304,7 +304,7 @@ func (r *AuthProxyWorkloadReconciler) updateAnnotation(wl workload.Workload, res
 		return
 	}
 
-	k, v := workload.PodAnnotation(resource)
+	k, v := r.updater.PodAnnotation(resource)
 
 	// add the annotation if needed...
 	an := wl.PodTemplateAnnotations()

--- a/internal/controller/pod_controller_test.go
+++ b/internal/controller/pod_controller_test.go
@@ -151,7 +151,7 @@ func podWebhookController(cb client.Client) (*PodAdmissionWebhook, context.Conte
 	r := &PodAdmissionWebhook{
 		Client:  cb,
 		decoder: d,
-		updater: workload.NewUpdater("cloud-sql-proxy-operator/dev"),
+		updater: workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage),
 	}
 
 	return r, ctx, nil

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -38,8 +38,8 @@ func InitScheme(scheme *runtime.Scheme) {
 
 // SetupManagers was moved out of ../main.go to here so that it can be invoked
 // from the testintegration tests AND from the actual operator.
-func SetupManagers(mgr manager.Manager, userAgent string) error {
-	u := workload.NewUpdater(userAgent)
+func SetupManagers(mgr manager.Manager, userAgent, defaultProxyImage string) error {
+	u := workload.NewUpdater(userAgent, defaultProxyImage)
 
 	setupLog.Info("Configuring reconcilers...")
 	var err error

--- a/internal/testintegration/setup.go
+++ b/internal/testintegration/setup.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/controller"
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/testhelpers"
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/workload"
 	"github.com/go-logr/logr"
 	"go.uber.org/zap/zapcore"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -143,7 +144,7 @@ func EnvTestSetup() (func(), error) {
 		return teardownFunc, fmt.Errorf("unable to start kuberenetes envtest %v", err)
 	}
 
-	err = controller.SetupManagers(mgr, "cloud-sql-proxy-operator/dev")
+	err = controller.SetupManagers(mgr, "cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	if err != nil {
 		return teardownFunc, fmt.Errorf("unable to start kuberenetes envtest %v", err)
 	}

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -36,6 +36,9 @@ import (
 // package and documented here so that they appear in the godoc. These also
 // need to be documented in the CRD
 const (
+	// DefaultProxyImage is the latest version of the proxy as of the release
+	// of this operator. This is managed as a dependency. We update this constant
+	// when the Cloud SQL Auth Proxy releases a new version.
 	DefaultProxyImage = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.1.1"
 
 	// DefaultFirstPort is the first port number chose for an instance listener by the
@@ -56,27 +59,42 @@ var l = logf.Log.WithName("internal.workload")
 // PodAnnotation returns the annotation (key, value) that should be added to
 // pods that are configured with this AuthProxyWorkload resource. This takes
 // into account whether the AuthProxyWorkload exists or was recently deleted.
-func PodAnnotation(r *cloudsqlapi.AuthProxyWorkload) (string, string) {
+// The defaultProxyImage is part of the annotation value.
+func PodAnnotation(r *cloudsqlapi.AuthProxyWorkload, defaultProxyImage string) (string, string) {
+	img := defaultProxyImage
+	if r.Spec.AuthProxyContainer != nil && r.Spec.AuthProxyContainer.Image != "" {
+		img = ""
+	}
 	k := fmt.Sprintf("%s/%s", cloudsqlapi.AnnotationPrefix, r.Name)
-	v := fmt.Sprintf("%d", r.Generation)
+	v := fmt.Sprintf("%d,%s", r.Generation, img)
 	// if r was deleted, use a different value
 	if !r.GetDeletionTimestamp().IsZero() {
-		v = fmt.Sprintf("%d-deleted-%s", r.Generation, r.GetDeletionTimestamp().Format(time.RFC3339))
+		v = fmt.Sprintf("%d-deleted-%s,%s", r.Generation, r.GetDeletionTimestamp().Format(time.RFC3339), img)
 	}
 
 	return k, v
+}
+
+// PodAnnotation returns the annotation (key, value) that should be added to
+// pods that are configured with this AuthProxyWorkload resource. This takes
+// into account whether the AuthProxyWorkload exists or was recently deleted.
+func (u *Updater) PodAnnotation(r *cloudsqlapi.AuthProxyWorkload) (string, string) {
+	return PodAnnotation(r, u.defaultProxyImage)
 }
 
 // Updater holds global state used while reconciling workloads.
 type Updater struct {
 	// userAgent is the userAgent of the operator
 	userAgent string
+
+	// defaultProxyImage is the current default proxy image for the operator
+	defaultProxyImage string
 }
 
 // NewUpdater creates a new instance of Updater with a supplier
 // that loads the default proxy impage from the public docker registry
-func NewUpdater(userAgent string) *Updater {
-	return &Updater{userAgent: userAgent}
+func NewUpdater(userAgent string, defaultProxyImage string) *Updater {
+	return &Updater{userAgent: userAgent, defaultProxyImage: defaultProxyImage}
 }
 
 // ConfigError is an error with extra details about why an AuthProxyWorkload
@@ -466,7 +484,7 @@ func (s *updateState) update(wl *PodWorkload, matches []*cloudsqlapi.AuthProxyWo
 		containers = append(containers, newContainer)
 
 		// Add pod annotation for each instance
-		k, v := PodAnnotation(inst)
+		k, v := s.updater.PodAnnotation(inst)
 		ann[k] = v
 	}
 
@@ -845,7 +863,7 @@ func (s *updateState) addError(errorCode, description string, p *cloudsqlapi.Aut
 }
 
 func (s *updateState) defaultProxyImage() string {
-	return DefaultProxyImage
+	return s.updater.defaultProxyImage
 }
 
 func (s *updateState) usePort(configValue *int32, defaultValue int32, p *cloudsqlapi.AuthProxyWorkload) int32 {

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -139,7 +139,7 @@ func TestUpdatePodWorkload(t *testing.T) {
 		wantContainerName       = "csql-default-" + wantsName
 		wantsInstanceName       = "project:server:db"
 		wantsInstanceArg        = fmt.Sprintf("%s?port=%d", wantsInstanceName, wantsPort)
-		u                       = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u                       = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 	var err error
 
@@ -194,7 +194,7 @@ func TestUpdateWorkloadFixedPort(t *testing.T) {
 			"DB_HOST": "127.0.0.1",
 			"DB_PORT": strconv.Itoa(int(wantsPort)),
 		}
-		u = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod
@@ -262,7 +262,7 @@ func TestWorkloadNoPortSet(t *testing.T) {
 			"DB_PORT": strconv.Itoa(int(wantsPort)),
 		}
 	)
-	u := workload.NewUpdater("cloud-sql-proxy-operator/dev")
+	u := workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 
 	// Create a pod
 	wl := podWorkload()
@@ -320,7 +320,7 @@ func TestContainerImageChanged(t *testing.T) {
 	var (
 		wantsInstanceName = "project:server:db"
 		wantImage         = "custom-image:latest"
-		u                 = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u                 = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod
@@ -362,7 +362,7 @@ func TestContainerImageEmpty(t *testing.T) {
 	var (
 		wantsInstanceName = "project:server:db"
 		wantImage         = workload.DefaultProxyImage
-		u                 = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u                 = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 	// Create a AuthProxyWorkload that matches the deployment
 
@@ -421,7 +421,7 @@ func TestContainerReplaced(t *testing.T) {
 		wantContainer     = &corev1.Container{
 			Name: "sample", Image: "debian:latest", Command: []string{"/bin/bash"},
 		}
-		u = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod
@@ -475,7 +475,7 @@ func TestResourcesFromSpec(t *testing.T) {
 			},
 		}
 
-		u = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod
@@ -725,7 +725,7 @@ func TestProxyCLIArgs(t *testing.T) {
 
 	for _, tc := range testcases {
 		t.Run(tc.desc, func(t *testing.T) {
-			u := workload.NewUpdater("cloud-sql-proxy-operator/dev")
+			u := workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 
 			// Create a pod
 			wl := &workload.PodWorkload{Pod: &corev1.Pod{
@@ -857,11 +857,11 @@ func TestPodTemplateAnnotations(t *testing.T) {
 		now = metav1.Now()
 
 		wantAnnotations = map[string]string{
-			"cloudsql.cloud.google.com/instance1": "1",
-			"cloudsql.cloud.google.com/instance2": "2",
+			"cloudsql.cloud.google.com/instance1": "1," + workload.DefaultProxyImage,
+			"cloudsql.cloud.google.com/instance2": "2," + workload.DefaultProxyImage,
 		}
 
-		u = workload.NewUpdater("cloud-sql-proxy-operator/dev")
+		u = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod
@@ -908,17 +908,17 @@ func TestPodAnnotation(t *testing.T) {
 			name:  "instance1",
 			r:     server,
 			wantK: "cloudsql.cloud.google.com/instance1",
-			wantV: "1",
+			wantV: fmt.Sprintf("1,%s", workload.DefaultProxyImage),
 		}, {
 			name:  "instance2",
 			r:     deletedServer,
 			wantK: "cloudsql.cloud.google.com/instance2",
-			wantV: fmt.Sprintf("2-deleted-%s", now.Format(time.RFC3339)),
+			wantV: fmt.Sprintf("2-deleted-%s,%s", now.Format(time.RFC3339), workload.DefaultProxyImage),
 		},
 	}
 
 	for _, tc := range testcases {
-		gotK, gotV := workload.PodAnnotation(tc.r)
+		gotK, gotV := workload.PodAnnotation(tc.r, workload.DefaultProxyImage)
 		if tc.wantK != gotK {
 			t.Errorf("got %v, want %v for key", gotK, tc.wantK)
 		}
@@ -942,7 +942,7 @@ func TestWorkloadUnixVolume(t *testing.T) {
 		wantWorkloadEnv = map[string]string{
 			"DB_SOCKET_PATH": wantsUnixSocketPath,
 		}
-		u = workload.NewUpdater("authproxyworkload/dev")
+		u = workload.NewUpdater("authproxyworkload/dev", workload.DefaultProxyImage)
 	)
 
 	// Create a pod

--- a/main.go
+++ b/main.go
@@ -20,6 +20,8 @@ import (
 	"runtime"
 
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/controller"
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/workload"
+
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
@@ -87,7 +89,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	err = controller.SetupManagers(mgr, userAgent)
+	err = controller.SetupManagers(mgr, userAgent, workload.DefaultProxyImage)
 	if err != nil {
 		setupLog.Error(err, "unable to set up the controllers")
 		os.Exit(1)


### PR DESCRIPTION
When an AuthProxyWorkload uses the default proxy image, use the operator's default proxy image 
and the AuthProxyWorkload.Generation together as a key to determine if a workload's proxy containers
need to be updated. 

Add tests to ensure that when the default image hardcoded into the operator changes, workloads using 
the old default will be identified and reconfigured properly.

There is another PR coming after this one which will automatically check and apply configuration 
changes to AuthProxyWorkload resources on operator startup.

Related to #87 