### PR TITLE
feat: Automatically update default images on operator startup.

### DIFF
--- a/internal/controller/proxy_image_upgrade.go
+++ b/internal/controller/proxy_image_upgrade.go
@@ -1,0 +1,71 @@
+// Copyright 2023 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/log"
+)
+
+// upgradeDefaultProxyOnStartup is a LeaderElectionRunnable task that will run
+// as soon as ControllerRuntime is initialized. It will list all AuthProxyWorkload
+// resources in the cluster, and force an update on all resources with the
+// default proxy image. If the operator has a different DefaultProxyImage than
+// the one used when that AuthProxyWorkload was last reconciled, then Reconcile
+// will update the associated workloads in accordance with the RolloutStrategy.
+type upgradeDefaultProxyOnStartup struct {
+	c client.Client
+}
+
+// Start lists all the AuthProxyWorkload resources and triggers the update on
+// the resources with a default proxy image.
+func (c *upgradeDefaultProxyOnStartup) Start(ctx context.Context) error {
+	l := &v1alpha1.AuthProxyWorkloadList{}
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+			err := c.c.List(ctx, l, client.Continue(l.Continue))
+			if err != nil {
+				return fmt.Errorf("can't list AuthProxyWorkload on startup, %v", err)
+			}
+
+			for _, p := range l.Items {
+				useDefaultImage := p.Spec.AuthProxyContainer == nil || p.Spec.AuthProxyContainer.Image == ""
+
+				if !useDefaultImage {
+					continue
+				}
+
+				// If an APW has a default image, then perform an "update" on it so that
+				// the reconcile function runs and triggers the appropriate rolling updates.
+				log.FromContext(ctx).Info(fmt.Sprintf("Upgrading workload default images for %s/%s", p.Namespace, p.Namespace))
+				err = c.c.Update(ctx, &p)
+			}
+			if l.Continue == "" {
+				return nil
+			}
+		}
+	}
+}
+
+func (c *upgradeDefaultProxyOnStartup) NeedLeaderElection() bool {
+	return true // only run on the leader
+}

--- a/internal/controller/proxy_image_upgrade.go
+++ b/internal/controller/proxy_image_upgrade.go
@@ -18,7 +18,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
+	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
@@ -36,12 +36,16 @@ type upgradeDefaultProxyOnStartup struct {
 // Start lists all the AuthProxyWorkload resources and triggers the update on
 // the resources with a default proxy image.
 func (c *upgradeDefaultProxyOnStartup) Start(ctx context.Context) error {
-	l := &v1alpha1.AuthProxyWorkloadList{}
+	l := &cloudsqlapi.AuthProxyWorkloadList{}
+
 	for {
 		select {
 		case <-ctx.Done():
 			return nil
 		default:
+			// c.c.List() fills l with a paginated list of AuthProxyWorkloads.
+			// The token in l.Continue field is used get the next page of the list.
+			// the for loop exits when l.Continue is blank, meaning no more pages.
 			err := c.c.List(ctx, l, client.Continue(l.Continue))
 			if err != nil {
 				return fmt.Errorf("can't list AuthProxyWorkload on startup, %v", err)

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -72,6 +72,14 @@ func SetupManagers(mgr manager.Manager, userAgent, defaultProxyImage string) err
 		return err
 	}
 
+	// Add the runnable task that will upgrade the proxy image on workloads with
+	// default container image when  the operator first starts.
+	err = mgr.Add(&upgradeDefaultProxyOnStartup{c: mgr.GetClient()})
+	if err != nil {
+		setupLog.Error(err, "unable to start task to check all AuthProxyWorkloads on startup")
+		return err
+	}
+
 	setupLog.Info("Configuring reconcilers complete.")
 	return nil
 }

--- a/internal/testintegration/integration_test.go
+++ b/internal/testintegration/integration_test.go
@@ -257,7 +257,7 @@ func TestUpdateWorkloadContainerWhenDefaultProxyImageChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal("can't restart container", err)
 	}
-	
+
 	// Check that proxy container was added to pods
 	err = tcc.ExpectPodContainerCount(ctx, d.Spec.Selector, 2, "all")
 	if err != nil {

--- a/internal/testintegration/integration_test.go
+++ b/internal/testintegration/integration_test.go
@@ -193,6 +193,9 @@ func TestModifiesExistingDeployment(t *testing.T) {
 	}
 }
 
+// TestUpdateWorkloadContainerWhenDefaultProxyImageChanges is the test that
+// demonstrates that when the operator's default image changes, it will
+// automatically update the proxy container image on existing deployments.
 func TestUpdateWorkloadContainerWhenDefaultProxyImageChanges(t *testing.T) {
 	ctx := testintegration.TestContext()
 	tcc := newTestCaseClient("modifynew")

--- a/internal/testintegration/integration_test.go
+++ b/internal/testintegration/integration_test.go
@@ -18,12 +18,17 @@
 package testintegration_test
 
 import (
+	"context"
 	"os"
 	"testing"
 
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/testhelpers"
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/testintegration"
+	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/workload"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 func TestMain(m *testing.M) {
@@ -47,7 +52,6 @@ func newTestCaseClient(name string) *testhelpers.TestCaseClient {
 		Client:           testintegration.Client,
 		Namespace:        testhelpers.NewNamespaceName(name),
 		ConnectionString: "region:project:inst",
-		ProxyImageURL:    "proxy-image:latest",
 	}
 }
 
@@ -178,26 +182,128 @@ func TestModifiesExistingDeployment(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Then we simulate the deployment pods being replaced
-	err = tcc.Client.Delete(ctx, rs1)
+	err = recreatePodsAfterDeploymentUpdate(ctx, tcc, d, rs1, pods)
 	if err != nil {
 		t.Fatal(err)
 	}
-
-	for i := 0; i < len(pods); i++ {
-		err = tcc.Client.Delete(ctx, pods[i])
-		if err != nil {
-			t.Fatal(err)
-		}
-	}
-	_, _, err = tcc.CreateDeploymentReplicaSetAndPods(ctx, d)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// and check for 2 containers
 	err = tcc.ExpectPodContainerCount(ctx, d.Spec.Selector, 2, "all")
 	if err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestUpdateWorkloadContainerWhenDefaultProxyImageChanges(t *testing.T) {
+	ctx := testintegration.TestContext()
+	tcc := newTestCaseClient("modifynew")
+
+	err := tcc.CreateOrPatchNamespace(ctx)
+	if err != nil {
+		t.Fatalf("can't create namespace, %v", err)
+	}
+
+	const (
+		pwlName            = "newdeploy"
+		deploymentAppLabel = "busybox"
+	)
+	key := types.NamespacedName{Name: pwlName, Namespace: tcc.Namespace}
+
+	t.Log("Creating AuthProxyWorkload")
+	p, err := tcc.CreateAuthProxyWorkload(ctx, key, deploymentAppLabel, tcc.ConnectionString, "Deployment")
+	if err != nil {
+		t.Error(err)
+		return
+	}
+
+	t.Log("Waiting for AuthProxyWorkload operator to begin the reconcile loop")
+	_, err = tcc.GetAuthProxyWorkloadAfterReconcile(ctx, key)
+	if err != nil {
+		t.Error("unable to create AuthProxyWorkload", err)
+		return
+	}
+
+	t.Log("Creating deployment")
+	d := testhelpers.BuildDeployment(key, deploymentAppLabel)
+	err = tcc.CreateWorkload(ctx, d)
+	if err != nil {
+		t.Error("unable to create deployment", err)
+		return
+	}
+
+	t.Log("Creating deployment replicas")
+	rs, pl, err := tcc.CreateDeploymentReplicaSetAndPods(ctx, d)
+	if err != nil {
+		t.Error("unable to create pods", err)
+		return
+	}
+
+	// Check that proxy container was added to pods
+	err = tcc.ExpectPodContainerCount(ctx, d.Spec.Selector, 2, "all")
+	if err != nil {
+		t.Error(err)
+	}
+
+	// Check that the pods have the expected default proxy image
+	pods, err := testhelpers.ListPods(ctx, tcc.Client, tcc.Namespace, d.Spec.Selector)
+	for _, p := range pods.Items {
+		if got, want := p.Spec.Containers[1].Image, workload.DefaultProxyImage; got != want {
+			t.Errorf("got %v, want %v image before operator upgrade", got, want)
+		}
+	}
+
+	// Restart the manager with a new default proxy image
+	const newDefault = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:999.9.9"
+	err = testintegration.RestartManager(newDefault)
+	if err != nil {
+		t.Fatal("can't restart container", err)
+	}
+
+	// Get the related deployment. Make sure that annotations were
+	// set on the pod template
+	ud := &appsv1.Deployment{}
+	err = tcc.Client.Get(ctx, client.ObjectKeyFromObject(d), ud)
+	if err != nil {
+		t.Error(err)
+	}
+	wantK, wantV := workload.PodAnnotation(p, newDefault)
+	gotV := ud.Spec.Template.Annotations[wantK]
+	if gotV != wantV {
+		t.Errorf("Got %s, want %s for podspec annotation", gotV, wantV)
+	}
+
+	// Recreate the ReplicaSet and Pods as would happen when the deployment
+	// PodTemplate changed.
+	err = recreatePodsAfterDeploymentUpdate(ctx, tcc, d, rs, pl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that the new pods have the new default proxy image
+	pods, err = testhelpers.ListPods(ctx, tcc.Client, tcc.Namespace, d.Spec.Selector)
+	for _, p := range pods.Items {
+		if got, want := p.Spec.Containers[1].Image, newDefault; got != want {
+			t.Errorf("got %v, want %v image before operator upgrade", got, want)
+		}
+	}
+
+}
+
+func recreatePodsAfterDeploymentUpdate(ctx context.Context, tcc *testhelpers.TestCaseClient, d *appsv1.Deployment, rs1 *appsv1.ReplicaSet, pods []*corev1.Pod) error {
+	// Then we simulate the deployment pods being replaced
+	err := tcc.Client.Delete(ctx, rs1)
+	if err != nil {
+		return err
+	}
+
+	for i := 0; i < len(pods); i++ {
+		err = tcc.Client.Delete(ctx, pods[i])
+		if err != nil {
+			return err
+		}
+	}
+	_, _, err = tcc.CreateDeploymentReplicaSetAndPods(ctx, d)
+	if err != nil {
+		return err
+	}
+	return nil
 }

--- a/internal/testintegration/integration_test.go
+++ b/internal/testintegration/integration_test.go
@@ -257,6 +257,12 @@ func TestUpdateWorkloadContainerWhenDefaultProxyImageChanges(t *testing.T) {
 	if err != nil {
 		t.Fatal("can't restart container", err)
 	}
+	
+	// Check that proxy container was added to pods
+	err = tcc.ExpectPodContainerCount(ctx, d.Spec.Selector, 2, "all")
+	if err != nil {
+		t.Error(err)
+	}
 
 	// Get the related deployment. Make sure that annotations were
 	// set on the pod template

--- a/internal/testintegration/setup.go
+++ b/internal/testintegration/setup.go
@@ -31,12 +31,13 @@ import (
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/workload"
 	"github.com/go-logr/logr"
 	"go.uber.org/zap/zapcore"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
-
+	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 )
 
 const kubeVersion = "1.24.1"
@@ -52,6 +53,9 @@ var (
 
 	// Client is the kubernetes client.
 	Client client.Client
+
+	// RestartManager is the controller-runtime manager for the operator
+	RestartManager func(string) error
 )
 
 // TestContext returns a background context that includes appropriate logging configuration.
@@ -130,6 +134,23 @@ func EnvTestSetup() (func(), error) {
 		return teardownFunc, fmt.Errorf("unable to start kuberenetes envtest %v", err)
 	}
 
+	mgrCancelFunc, err := startManager(ctx, cfg, s, workload.DefaultProxyImage)
+	if err != nil {
+		return teardownFunc, fmt.Errorf("unable to start kuberenetes envtest %v", err)
+	}
+
+	RestartManager = func(defaultProxyImage string) error {
+		mgrCancelFunc()
+		mgrCancelFunc, err = startManager(ctx, cfg, s, defaultProxyImage)
+		return err
+	}
+
+	return teardownFunc, nil
+}
+
+func startManager(ctx context.Context, cfg *rest.Config, s *runtime.Scheme, proxyImage string) (context.CancelFunc, error) {
+	ctx, managerCancelFunc := context.WithCancel(ctx)
+
 	// start webhook server using Manager
 	o := &testEnv.WebhookInstallOptions
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
@@ -141,12 +162,13 @@ func EnvTestSetup() (func(), error) {
 		MetricsBindAddress: "0",
 	})
 	if err != nil {
-		return teardownFunc, fmt.Errorf("unable to start kuberenetes envtest %v", err)
+		return managerCancelFunc, fmt.Errorf("unable to start kuberenetes envtest %v", err)
 	}
 
-	err = controller.SetupManagers(mgr, "cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
+	err = controller.SetupManagers(mgr, "cloud-sql-proxy-operator/dev", proxyImage)
+
 	if err != nil {
-		return teardownFunc, fmt.Errorf("unable to start kuberenetes envtest %v", err)
+		return managerCancelFunc, fmt.Errorf("unable to start kuberenetes envtest %v", err)
 	}
 
 	go func() {
@@ -178,5 +200,5 @@ func EnvTestSetup() (func(), error) {
 
 	Log.Info("Setup complete. Webhook server started.")
 
-	return teardownFunc, nil
+	return managerCancelFunc, nil
 }


### PR DESCRIPTION
When the operator starts, run a function that will list all AuthProxyWorkloads, find ones that are using the
default proxy image, and trigger an update on those AuthProxyWorkloads. This will cause the Reconcile 
function to ensure that the AuthProxyWorkloads are running the latest default version of the proxy image. 

Fixes #87 