### PR TITLE
chore: Use package alias cloudsqlapi for ./internal/api/v1alpha

### DIFF
--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -15,7 +15,7 @@
 package controller
 
 import (
-	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
+	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/workload"
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -32,7 +32,7 @@ var setupLog = ctrl.Log.WithName("setup")
 func InitScheme(scheme *runtime.Scheme) {
 	utilruntime.Must(clientgoscheme.AddToScheme(scheme))
 
-	utilruntime.Must(v1alpha1.AddToScheme(scheme))
+	utilruntime.Must(cloudsqlapi.AddToScheme(scheme))
 	//+kubebuilder:scaffold:scheme
 }
 
@@ -54,7 +54,7 @@ func SetupManagers(mgr manager.Manager, userAgent string) error {
 		return err
 	}
 
-	wh := &v1alpha1.AuthProxyWorkload{}
+	wh := &cloudsqlapi.AuthProxyWorkload{}
 	err = wh.SetupWebhookWithManager(mgr)
 	if err != nil {
 		setupLog.Error(err, "unable to create webhook", "webhook", "AuthProxyWorkload")

--- a/internal/workload/names_test.go
+++ b/internal/workload/names_test.go
@@ -19,7 +19,7 @@ import (
 
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/workload"
 
-	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
+	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
 )
 
 func TestSafePrefixedName(t *testing.T) {
@@ -73,7 +73,7 @@ func TestSafePrefixedName(t *testing.T) {
 }
 
 func TestContainerName(t *testing.T) {
-	csql := authProxyWorkload("hello-world", []v1alpha1.InstanceSpec{{ConnectionString: "proj:inst:db"}})
+	csql := authProxyWorkload("hello-world", []cloudsqlapi.InstanceSpec{{ConnectionString: "proj:inst:db"}})
 	got := workload.ContainerName(csql)
 	want := "csql-default-hello-world"
 	if want != got {
@@ -82,7 +82,7 @@ func TestContainerName(t *testing.T) {
 }
 
 func TestVolumeName(t *testing.T) {
-	csql := authProxyWorkload("hello-world", []v1alpha1.InstanceSpec{{ConnectionString: "proj:inst:db"}})
+	csql := authProxyWorkload("hello-world", []cloudsqlapi.InstanceSpec{{ConnectionString: "proj:inst:db"}})
 	got := workload.VolumeName(csql, &csql.Spec.Instances[0], "temp")
 	want := "csql-hello-world-temp-proj-inst-db"
 	if want != got {


### PR DESCRIPTION
Update all files to use the import alias `cloudsqlapi` for the package
 "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1".

The API package name is going to change from `v1alpha1` to `v1` soon and we don't want a ton 
of irrelevant changes throughout the files. Thus, we want to use the package alias throughout the
code so that the package rename change is concise.
