### PR TITLE
chore: lint for use of cloudsqlapi package alias

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,9 +17,15 @@ linters:
   enable:
     - goimports
     - revive
+    - importas
 issues:
   exclude-use-default: false
 linters-settings:
+  importas:
+    no-unaliased: true
+    alias:
+    - pkg: "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
+      alias: "cloudsqlapi"
   revive:
     rules:
       - name: blank-imports

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -24,8 +24,8 @@ linters-settings:
   importas:
     no-unaliased: true
     alias:
-    - pkg: "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
-      alias: "cloudsqlapi"
+      - pkg: "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1"
+        alias: "cloudsqlapi"
   revive:
     rules:
       - name: blank-imports


### PR DESCRIPTION
Configure the linter to make sure that go code always imports 
`github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1alpha1` 
with the alias `cloudsqlapi`.