### PR TITLE
chore: Upgrade to cert-manager 1.11.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,7 @@ SHELL = /usr/bin/env bash -o pipefail
 .SHELLFLAGS = -ec
 
 ## The version to use for the cert-manager operator
-CERT_MANAGER_VERSION=v1.9.1
+CERT_MANAGER_VERSION=v1.11.0# renovate datasource=github-tags depName=cert-manager/cert-manager
 
 ##@ General
 
@@ -337,31 +337,8 @@ e2e_cluster_destroy: e2e_project terraform # Destroy the infrastructure for e2e 
 
 .PHONY: e2e_cert_manager_deploy
 e2e_cert_manager_deploy: e2e_project helm # Deploy the certificate manager
-	helm repo add jetstack https://charts.jetstack.io --kubeconfig=$(KUBECONFIG_E2E)
-	helm repo add jetstack https://charts.jetstack.io --kubeconfig=$(PRIVATE_KUBECONFIG_E2E)
-
-	helm repo update --kubeconfig=$(KUBECONFIG_E2E)
-	helm repo update --kubeconfig=$(PRIVATE_KUBECONFIG_E2E)
-
-	helm get all -n cert-manager cert-manager --kubeconfig=$(KUBECONFIG_E2E)  || \
-		helm --kubeconfig=$(KUBECONFIG_E2E) install \
-			cert-manager jetstack/cert-manager \
-			--kubeconfig=$(KUBECONFIG_E2E) \
-			--namespace cert-manager \
-			--version "$(CERT_MANAGER_VERSION)" \
-			--create-namespace \
-			--set global.leaderElection.namespace=cert-manager \
-			--set installCRDs=true
-	helm get all -n cert-manager cert-manager --kubeconfig=$(PRIVATE_KUBECONFIG_E2E)  || \
-		helm --kubeconfig=$(PRIVATE_KUBECONFIG_E2E) install \
-			cert-manager jetstack/cert-manager \
-			--kubeconfig=$(PRIVATE_KUBECONFIG_E2E) \
-			--namespace cert-manager \
-			--version "$(CERT_MANAGER_VERSION)" \
-			--create-namespace \
-			--set global.leaderElection.namespace=cert-manager \
-			--set installCRDs=true
-
+	KUBECONFIG=$(KUBECONFIG_E2E) CERT_MANAGER_VERSION=$(CERT_MANAGER_VERSION) tools/helm-install-certmanager.sh
+	KUBECONFIG=$(PRIVATE_KUBECONFIG_E2E) CERT_MANAGER_VERSION=$(CERT_MANAGER_VERSION) tools/helm-install-certmanager.sh
 
 .PHONY: e2e_install_crd
 e2e_install_crd: generate e2e_project kustomize kubectl $(E2E_WORK_DIR) # Install CRDs into the GKE cluster

--- a/installer/install.sh
+++ b/installer/install.sh
@@ -19,8 +19,8 @@ set -euxo # exit 1 from the script when command fails
 # If CSQL_OPERATOR_VERSION is not set, use the release version: v0.4.0-dev.
 CSQL_OPERATOR_VERSION="${CSQL_OPERATOR_VERSION:-v0.4.0-dev}"
 
-# If CSQL_CERT_MANAGER_VERSION is not set, use the default: v1.9.1.
-CSQL_CERT_MANAGER_VERSION="${CSQL_CERT_MANAGER_VERSION:-v1.9.1}"
+# If CSQL_CERT_MANAGER_VERSION is not set, use the default: v1.11.0.
+CSQL_CERT_MANAGER_VERSION="${CSQL_CERT_MANAGER_VERSION:-v1.11.0}"
 
 # If CSQL_OPERATOR_URL is not set, use the default value from the CSQL_OPERATOR_VERSION
 CSQL_OPERATOR_URL="${CSQL_OPERATOR_URL:-https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy-operator/$CSQL_OPERATOR_VERSION/cloud-sql-proxy-operator.yaml}"

--- a/tools/helm-install-certmanager.sh
+++ b/tools/helm-install-certmanager.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Configure script to fail on any command error
+set -euxo pipefail
+
+# Find project directory, cd to project directory
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+PROJECT_DIR=$( dirname "$SCRIPT_DIR")
+cd "$PROJECT_DIR"
+
+# Validate input environment variables
+#expects KUBECONFIG to be set by the caller
+if [[ -z "${KUBECONFIG:-}" ]]; then
+  echo "expects KUBECONFIG to be the path to the kubeconfig file for kubectl."
+  exit 1
+fi
+
+#expects CERT_MANAGER_VERSION to be set by the caller
+if [[ -z "${CERT_MANAGER_VERSION:-}" ]]; then
+  echo "expects CERT_MANAGER_VERSION to be set the version of cert manager to install."
+  exit 1
+fi
+
+helm repo add jetstack https://charts.jetstack.io --kubeconfig "${KUBECONFIG}"
+helm repo update --kubeconfig "${KUBECONFIG}"
+
+if helm get all -n cert-manager cert-manager --kubeconfig "${KUBECONFIG}" > /dev/null ; then
+  action="upgrade"
+else
+  action="install"
+fi
+
+helm --kubeconfig "${KUBECONFIG}" "$action" \
+  cert-manager jetstack/cert-manager \
+  --namespace cert-manager \
+  --version "${CERT_MANAGER_VERSION}" \
+  --create-namespace \
+  --set global.leaderElection.namespace=cert-manager \
+  --set installCRDs=true

--- a/tools/helm-install-certmanager.sh
+++ b/tools/helm-install-certmanager.sh
@@ -1,4 +1,18 @@
 #!/usr/bin/env bash
+# Copyright 2023 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 
 # Configure script to fail on any command error
 set -euxo pipefail


### PR DESCRIPTION
This upgrades the cluster to cert-manager 1.11.0, adds comments so that cert-manager
is automatically upgraded by renovate.

Also, this moves e2e helm script commands out of the Makefile and into their own shell script.
The helm-related commands  had grown too complex for a Makefile target. 