### PR TITLE
chore: pin workflow to sha

### DIFF
--- a/.github/workflows/release-please-updates.yaml
+++ b/.github/workflows/release-please-updates.yaml
@@ -29,7 +29,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - name: Generate code and commit differences
         run: tools/release-pr-generate.sh

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -66,7 +66,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
-          ref: ${{ github.event.pull_request.head.ref }}
+          ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: 'auth'
         name: 'Authenticate to Google Cloud'


### PR DESCRIPTION
Pin to sha instead of ref