### PR TITLE
chore: omit yaml files in .github/workflows from yaml fmt.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -125,7 +125,7 @@ go_fmt: # Automatically formats go files
 	go run golang.org/x/tools/cmd/goimports@latest -w .
 
 yaml_fmt: # Automatically formats all yaml files
-	go run github.com/UltiRequiem/yamlfmt@latest -w $(shell find . -iname '*.yaml' -or -iname '*.yml' | grep -v -e '^./bin/')
+	go run github.com/UltiRequiem/yamlfmt@latest -w $(shell find . -iname '*.yaml' -or -iname '*.yml' | grep -v -e '^./bin/' | grep -v -e '^./.github/workflows/')
 
 .PHONY: add_copyright_header
 add_copyright_header: # Add the copyright header


### PR DESCRIPTION
Don't run yaml_fmt on .github/workflows. This is unnecessary and makes the code harder to read.