### PR TITLE
ci: change name of ci environment to 'ci-branch-main' to avoid terraform issues

### DIFF
--- a/.github/workflows/tests-main.yaml
+++ b/.github/workflows/tests-main.yaml
@@ -69,7 +69,7 @@ jobs:
         name: 'Run E2E Tests'
         run: "./tools/e2e_test_job.sh"
         env:
-          ENVIRONMENT_NAME: "ci-daily"
+          ENVIRONMENT_NAME: "ci-branch-main"
           NODEPOOL_SERVICEACCOUNT_EMAIL: "${{secrets.NODEPOOL_SERVICEACCOUNT_EMAIL}}"
           WORKLOAD_ID_SERVICEACCOUNT_EMAIL: "${{secrets.WORKLOAD_ID_SERVICEACCOUNT_EMAIL}}"
           TFSTATE_STORAGE_BUCKET: "${{secrets.TFSTATE_STORAGE_BUCKET}}"

--- a/.github/workflows/tests-main.yaml
+++ b/.github/workflows/tests-main.yaml
@@ -69,7 +69,7 @@ jobs:
         name: 'Run E2E Tests'
         run: "./tools/e2e_test_job.sh"
         env:
-          ENVIRONMENT_NAME: "ci-main"
+          ENVIRONMENT_NAME: "ci-daily"
           NODEPOOL_SERVICEACCOUNT_EMAIL: "${{secrets.NODEPOOL_SERVICEACCOUNT_EMAIL}}"
           WORKLOAD_ID_SERVICEACCOUNT_EMAIL: "${{secrets.WORKLOAD_ID_SERVICEACCOUNT_EMAIL}}"
           TFSTATE_STORAGE_BUCKET: "${{secrets.TFSTATE_STORAGE_BUCKET}}"


### PR DESCRIPTION
Terraform has a hard time tearing down and recreating whole environments when they are 
too far out of date. Instead, this starts a brand new environment named 'ci-daily'. 

I will manually delete the old environment 'ci-main' to free up cloud resources.