### PR TITLE
chore: pin actions to SHA and make workflows read-all

### DIFF
--- a/.github/workflows/release-please-updates.yaml
+++ b/.github/workflows/release-please-updates.yaml
@@ -16,18 +16,23 @@ name: Release PR
 on:
   pull_request:
     types: [opened, synchronize, reopened, labeled]
+# Declare default permissions as read only.
+permissions: read-all
 jobs:
   build:
     name: "Code Generation"
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     if: "${{ github.actor == 'release-please[bot]' }}"
     steps:
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: '1.20'
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -17,15 +17,20 @@ on:
   pull_request:
   pull_request_target:
     types: [labeled]
+# Declare default permissions as read only.
+permissions: read-all
 jobs:
   unit:
     if: "${{ github.event.action != 'labeled' || github.event.label.name == 'tests: run' }}"
     name: unit tests
     runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
     steps:
       - name: Remove PR Label
         if: "${{ github.event.action == 'labeled' && github.event.label.name == 'tests: run' }}"
-        uses: actions/github-script@v6
+        uses: actions/github-script@98814c53be79b1d30f795b907e553d8679345975 # v6.4.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
@@ -40,11 +45,11 @@ jobs:
               console.log('Failed to remove label. Another job may have already removed it!');
             }
       - name: Setup Go
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: '1.20'
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
@@ -62,31 +67,33 @@ jobs:
     permissions:
       contents: 'read'
       id-token: 'write'
+      issues: write
+      pull-requests: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}
       - id: 'auth'
-        name: 'Authenticate to Google Cloud'
-        uses: 'google-github-actions/auth@v1.0.0'
+        name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@ef5d53e30bbcd8d0836f4288f5e50ff3e086997d # v1.0.0
         with:
           workload_identity_provider: ${{ secrets.PROVIDER_NAME }}
           service_account: ${{ secrets.SERVICE_ACCOUNT }}
           access_token_lifetime: 600s
           project_id: ${{ secrets.GOOGLE_CLOUD_PROJECT }}
           create_credentials_file: true
-      - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v1'
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@62d4898025f6041e16b1068643bfc5a696863587 # v1.1.0
       - name: 'Setup Go'
-        uses: actions/setup-go@v3
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:
           go-version: '1.20'
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v2
+        uses: docker/setup-qemu-action@e81a89b1732b9c48d79cd809d8d81d79c4647a18 # v2.1.0
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v2
+        uses: docker/setup-buildx-action@4b4e9c3e2d4531116a6f8ba8e71fc6e2cb6e6c8c # v2.5.0
       - id: 'e2e'
         name: 'Run E2E Tests'
         run: "./tools/e2e_test_job.sh"


### PR DESCRIPTION
Take care of most `Pinned-Dependencies` and `Token-Permissions` alerts