### PR TITLE
fix: The e2e k8s node pool version should match the master version

### DIFF
--- a/infra/permissions/main.tf
+++ b/infra/permissions/main.tf
@@ -27,16 +27,21 @@ terraform {
 provider "google" {
   user_project_override = true
   billing_project       = var.project_id
+  project               = var.project_id
+  region                = var.gcloud_region
+  zone                  = var.gcloud_zone
 }
 
 # Enable gcloud project APIs
 locals {
   project_services = toset([
+    "artifactregistry.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
     "compute.googleapis.com",
     "container.googleapis.com",
-    "artifactregistry.googleapis.com",
     "deploymentmanager.googleapis.com",
     "dns.googleapis.com",
+    "iam.googleapis.com",
     "logging.googleapis.com",
     "monitoring.googleapis.com",
     "oslogin.googleapis.com",
@@ -48,7 +53,8 @@ locals {
     "servicenetworking.googleapis.com",
     "sql-component.googleapis.com",
     "sqladmin.googleapis.com",
-  "storage-api.googleapis.com"])
+    "storage-api.googleapis.com"
+  ])
 }
 
 resource "google_project_service" "project" {
@@ -72,6 +78,13 @@ resource "google_project_iam_member" "allow_image_pull" {
 resource "google_project_iam_binding" "cloud_sql_client" {
   project = var.project_id
   role    = "roles/cloudsql.client"
+  members = [
+    "serviceAccount:${google_service_account.node_pool.email}"
+  ]
+}
+resource "google_project_iam_binding" "service_usage_consumer" {
+  project = var.project_id
+  role    = "roles/serviceusage.serviceUsageConsumer"
   members = [
     "serviceAccount:${google_service_account.node_pool.email}"
   ]

--- a/infra/permissions/main.tf
+++ b/infra/permissions/main.tf
@@ -82,13 +82,6 @@ resource "google_project_iam_binding" "cloud_sql_client" {
     "serviceAccount:${google_service_account.node_pool.email}"
   ]
 }
-resource "google_project_iam_binding" "service_usage_consumer" {
-  project = var.project_id
-  role    = "roles/serviceusage.serviceUsageConsumer"
-  members = [
-    "serviceAccount:${google_service_account.node_pool.email}"
-  ]
-}
 
 ##
 # This is how you do an output file containing terraform data for use by

--- a/infra/resources/gke_cluster.tf
+++ b/infra/resources/gke_cluster.tf
@@ -49,7 +49,7 @@ resource "google_container_node_pool" "primary_preemptible_nodes" {
   name               = "operator-test-nodes-${var.environment_name}"
   cluster            = google_container_cluster.primary.id
   initial_node_count = var.workers_count
-  version            = data.google_container_engine_versions.supported.latest_node_version
+  version            = data.google_container_engine_versions.supported.latest_master_version
   location           = var.gcloud_zone
 
   autoscaling {

--- a/infra/resources/private_gke_cluster.tf
+++ b/infra/resources/private_gke_cluster.tf
@@ -47,7 +47,7 @@ resource "google_container_node_pool" "private_preemptible_nodes" {
   name               = "operator-private-nodes-${var.environment_name}"
   cluster            = google_container_cluster.private.id
   initial_node_count = var.workers_count
-  version            = data.google_container_engine_versions.supported.latest_node_version
+  version            = data.google_container_engine_versions.supported.latest_master_version
   location           = var.gcloud_zone
 
   autoscaling {


### PR DESCRIPTION
This fixes a bug in the e2e test landscape where the latest node version reported by the GKE API is 1.26.* while the latest 
master version reported by the GKE API is 1.25.*, causing an error. 