### PR TITLE
fix: delete misconfigured pods in error state.

### DIFF
--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -19,12 +19,15 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/json"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
 
 	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1"
@@ -56,6 +59,7 @@ func (a *PodAdmissionWebhook) Handle(ctx context.Context, req admission.Request)
 			"kind", req.Kind.Kind, "ns", req.Namespace, "name", req.Name)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
+	l.Info("received mutate pod request: ", "Kind", req.RequestKind, "Operation", req.Operation, "Name", req.Name, "Namespace", req.Namespace, "AdmissionRequest", req.AdmissionRequest)
 
 	updatedPod, err := a.handleCreatePodRequest(ctx, p)
 	if err != nil {
@@ -63,6 +67,7 @@ func (a *PodAdmissionWebhook) Handle(ctx context.Context, req admission.Request)
 	}
 
 	if updatedPod == nil {
+		l.Info("no changes", "Kind", req.RequestKind, "Operation", req.Operation, "Name", req.Name, "Namespace", req.Namespace)
 		return admission.Allowed("no changes to pod")
 	}
 
@@ -74,6 +79,7 @@ func (a *PodAdmissionWebhook) Handle(ctx context.Context, req admission.Request)
 		return admission.Errored(http.StatusInternalServerError,
 			fmt.Errorf("unable to marshal workload result"))
 	}
+	l.Info("updated pod", "Kind", req.RequestKind, "Operation", req.Operation, "Name", req.Name, "Namespace", req.Namespace)
 
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledRes)
 }
@@ -81,38 +87,16 @@ func (a *PodAdmissionWebhook) Handle(ctx context.Context, req admission.Request)
 // handleCreatePodRequest Finds relevant AuthProxyWorkload resources and updates the pod
 // with matching resources, returning a non-nil pod when the pod was updated.
 func (a *PodAdmissionWebhook) handleCreatePodRequest(ctx context.Context, p corev1.Pod) (*corev1.Pod, error) {
-	var (
-		instList    = &cloudsqlapi.AuthProxyWorkloadList{}
-		proxies     []*cloudsqlapi.AuthProxyWorkload
-		wlConfigErr error
-		l           = logf.FromContext(ctx)
-		wl          = &workload.PodWorkload{Pod: &p}
-	)
+	l := logf.FromContext(ctx)
+	wl := &workload.PodWorkload{Pod: &p}
 
-	// List all the AuthProxyWorkloads in the same namespace.
-	// To avoid privilege escalation, the operator requires that the AuthProxyWorkload
-	// may only affect pods in the same namespace.
-	err := a.Client.List(ctx, instList, client.InNamespace(wl.Object().GetNamespace()))
+	proxies, err := findMatchingProxies(ctx, a.Client, a.updater, wl)
 	if err != nil {
-		l.Error(err, "Unable to list CloudSqlClient resources in webhook",
-			"kind", wl.Pod.Kind, "ns", wl.Pod.Namespace, "name", wl.Pod.Name)
-		return nil, fmt.Errorf("unable to list AuthProxyWorkloads, %v", err)
-	}
-
-	// List the owners of this pod.
-	owners, err := a.listOwners(ctx, wl.Object())
-	if err != nil {
-		return nil, fmt.Errorf("there is an AuthProxyWorkloadConfiguration error reconciling this workload %v", err)
-	}
-
-	// Find matching AuthProxyWorkloads for this pod
-	proxies = a.updater.FindMatchingAuthProxyWorkloads(instList, wl, owners)
-	if len(proxies) == 0 {
-		return nil, nil // no change
+		return nil, err
 	}
 
 	// Configure the pod, adding containers for each of the proxies
-	wlConfigErr = a.updater.ConfigureWorkload(wl, proxies)
+	wlConfigErr := a.updater.ConfigureWorkload(wl, proxies)
 
 	if wlConfigErr != nil {
 		l.Error(wlConfigErr, "Unable to reconcile workload result in webhook: "+wlConfigErr.Error(),
@@ -123,9 +107,42 @@ func (a *PodAdmissionWebhook) handleCreatePodRequest(ctx context.Context, p core
 	return wl.Pod, nil // updated
 }
 
+func findMatchingProxies(ctx context.Context, c client.Client, u *workload.Updater, wl *workload.PodWorkload) ([]*cloudsqlapi.AuthProxyWorkload, error) {
+	var (
+		instList = &cloudsqlapi.AuthProxyWorkloadList{}
+		proxies  []*cloudsqlapi.AuthProxyWorkload
+		l        = logf.FromContext(ctx)
+	)
+
+	// List all the AuthProxyWorkloads in the same namespace.
+	// To avoid privilege escalation, the operator requires that the AuthProxyWorkload
+	// may only affect pods in the same namespace.
+	err := c.List(ctx, instList, client.InNamespace(wl.Object().GetNamespace()))
+	if err != nil {
+		l.Error(err, "Unable to list CloudSqlClient resources in webhook",
+			"kind", wl.Pod.Kind, "ns", wl.Pod.Namespace, "name", wl.Pod.Name)
+		return nil, fmt.Errorf("unable to list AuthProxyWorkloads, %v", err)
+	}
+
+	// List the owners of this pod.
+	owners, err := listOwners(ctx, c, wl.Object())
+	if err != nil {
+		return nil, fmt.Errorf("there is an AuthProxyWorkloadConfiguration error reconciling this workload %v", err)
+	}
+
+	// Find matching AuthProxyWorkloads for this pod
+	proxies = u.FindMatchingAuthProxyWorkloads(instList, wl, owners)
+	if len(proxies) == 0 {
+		return nil, nil // no change
+	}
+
+	return proxies, nil
+
+}
+
 // listOwners returns the list of this object's owners and its extended owners.
 // Warning: this is a recursive function
-func (a *PodAdmissionWebhook) listOwners(ctx context.Context, object client.Object) ([]workload.Workload, error) {
+func listOwners(ctx context.Context, c client.Client, object client.Object) ([]workload.Workload, error) {
 	l := logf.FromContext(ctx)
 	var owners []workload.Workload
 
@@ -143,7 +160,7 @@ func (a *PodAdmissionWebhook) listOwners(ctx context.Context, object client.Obje
 		owners = append(owners, wl)
 		owner = wl.Object()
 
-		err = a.Client.Get(ctx, key, owner)
+		err = c.Get(ctx, key, owner)
 		if err != nil {
 			switch t := err.(type) {
 			case *apierrors.StatusError:
@@ -159,7 +176,7 @@ func (a *PodAdmissionWebhook) listOwners(ctx context.Context, object client.Obje
 
 		// recursively call for the owners of the owner, and append those.
 		// So that we reach Pod --> ReplicaSet --> Deployment
-		ownerOwners, err := a.listOwners(ctx, owner)
+		ownerOwners, err := listOwners(ctx, c, owner)
 		if err != nil {
 			return nil, err
 		}
@@ -167,4 +184,100 @@ func (a *PodAdmissionWebhook) listOwners(ctx context.Context, object client.Obje
 		owners = append(owners, ownerOwners...)
 	}
 	return owners, nil
+}
+
+type PodEventHandler struct {
+	ctx context.Context
+	u   *workload.Updater
+	l   logr.Logger
+	mgr manager.Manager
+}
+
+// NeedLeaderElection implements manager.LeaderElectionRunnable so that
+// the PodEventHandler only runs on the leader, not on other redundant
+// pods.
+func (h *PodEventHandler) NeedLeaderElection() bool {
+	return true
+}
+
+// Start implements manager.Runnable which will start the informer receiving
+// pod change events on the operator's leader instance.
+func (h *PodEventHandler) Start(ctx context.Context) error {
+	h.ctx = ctx
+
+	i, err := h.mgr.GetCache().GetInformerForKind(ctx, schema.GroupVersionKind{
+		Group:   "",
+		Version: "v1",
+		Kind:    "Pod",
+	})
+	if err != nil {
+		return fmt.Errorf("Unable to get pod informer, %v", err)
+	}
+
+	_, err = i.AddEventHandler(h)
+	if err != nil {
+		return fmt.Errorf("Unable to register pod event handler, %v", err)
+	}
+	return nil
+
+}
+
+// OnAdd is called by the informer when a Pod is added.
+func (h *PodEventHandler) OnAdd(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	h.handlePodChanged(pod)
+}
+
+// OnUpdate is called by the informer when a Pod is updated.
+func (h *PodEventHandler) OnUpdate(_, newObj interface{}) {
+	newPod, ok := newObj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	h.handlePodChanged(newPod)
+}
+
+// OnUpdate is called by the informer when a Pod is deleted.
+func (h *PodEventHandler) OnDelete(obj interface{}) {
+	pod, ok := obj.(*corev1.Pod)
+	if !ok {
+		return
+	}
+	h.l.Info("Update pod: %v", "pod", pod)
+}
+
+// handlePodChanged Deletes pods that meet the following criteria:
+// 1. The pod is in Error or CrashLoopBackoff state.
+// 2. The pod should have one or more proxy sidecar containers.
+// 3. The pod is missing one or more proxy sidecar containers.
+func (h *PodEventHandler) handlePodChanged(pod *corev1.Pod) {
+	wl := &workload.PodWorkload{Pod: pod}
+	c := h.mgr.GetClient()
+
+	proxies, err := findMatchingProxies(h.ctx, c, h.u, wl)
+	if err != nil {
+		h.l.Error(err, "Unable to find proxies when pod changed")
+		return
+	}
+
+	// There are no proxies, nothing more to do.
+	if len(proxies) == 0 {
+		return
+	}
+
+	// Configure the pod, adding containers for each of the proxies
+	wlConfigErr := h.u.CheckWorkloadContainers(wl, proxies)
+
+	// If the pod has a config error, and the pod is not deleted, delete it.
+	if wlConfigErr != nil && pod.ObjectMeta.DeletionTimestamp.IsZero() {
+		h.l.Info("Pod configured incorrectly. Deleting.", "Namespace", pod.Namespace, "Name", pod.Name, "Status", pod.Status)
+		err = c.Delete(h.ctx, pod)
+		if err != nil && !apierrors.IsNotFound(err) {
+			h.l.Error(err, "Unable to delete pod.", "Namespace", pod.Namespace, "Name", pod.Name)
+		}
+	}
+
 }

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -59,7 +59,6 @@ func (a *PodAdmissionWebhook) Handle(ctx context.Context, req admission.Request)
 			"kind", req.Kind.Kind, "ns", req.Namespace, "name", req.Name)
 		return admission.Errored(http.StatusInternalServerError, err)
 	}
-	l.Info("received mutate pod request: ", "Kind", req.RequestKind, "Operation", req.Operation, "Name", req.Name, "Namespace", req.Namespace, "AdmissionRequest", req.AdmissionRequest)
 
 	updatedPod, err := a.handleCreatePodRequest(ctx, p)
 	if err != nil {
@@ -67,7 +66,6 @@ func (a *PodAdmissionWebhook) Handle(ctx context.Context, req admission.Request)
 	}
 
 	if updatedPod == nil {
-		l.Info("no changes", "Kind", req.RequestKind, "Operation", req.Operation, "Name", req.Name, "Namespace", req.Namespace)
 		return admission.Allowed("no changes to pod")
 	}
 
@@ -79,7 +77,6 @@ func (a *PodAdmissionWebhook) Handle(ctx context.Context, req admission.Request)
 		return admission.Errored(http.StatusInternalServerError,
 			fmt.Errorf("unable to marshal workload result"))
 	}
-	l.Info("updated pod", "Kind", req.RequestKind, "Operation", req.Operation, "Name", req.Name, "Namespace", req.Namespace)
 
 	return admission.PatchResponseFromRaw(req.Object.Raw, marshaledRes)
 }

--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -106,7 +106,7 @@ func (a *PodAdmissionWebhook) handleCreatePodRequest(ctx context.Context, p core
 		return nil, fmt.Errorf("there is an AuthProxyWorkloadConfiguration error reconciling this workload %v", wlConfigErr)
 	}
 
-	return wl.Pod, nil // updated
+	return wl.Pod, nil // updated pod
 }
 
 // findMatchingProxies lists all AuthProxyWorkloads that are related to this pod
@@ -196,7 +196,7 @@ type podDeleteController struct {
 	updater *workload.Updater
 }
 
-// newDeletePodController constructs an podDeleteController
+// newDeletePodController constructs a podDeleteController.
 func newPodDeleteController(mgr ctrl.Manager, u *workload.Updater) (*podDeleteController, error) {
 	r := &podDeleteController{
 		Client:  mgr.GetClient(),
@@ -254,10 +254,11 @@ func (r *podDeleteController) handlePodChanged(ctx context.Context, pod *corev1.
 		return nil
 	}
 
-	// Check if this pod is in error and missing proxy containers
+	// Check if this pod is in an error or waiting state and is missing
+	// proxy containers.
 	wlConfigErr := r.updater.CheckWorkloadContainers(wl, proxies)
 
-	// If this pod is in error, delete it. Simply logging an error is sufficient.
+	// If the pod is misconfigured, attempt to delete it.
 	if wlConfigErr != nil {
 		l := logf.FromContext(ctx)
 		l.Info("Pod configured incorrectly. Deleting.",

--- a/internal/controller/pod_controller_test.go
+++ b/internal/controller/pod_controller_test.go
@@ -21,7 +21,10 @@ import (
 	cloudsqlapi "github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/api/v1"
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/testhelpers"
 	"github.com/GoogleCloudPlatform/cloud-sql-proxy-operator/internal/workload"
+	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -155,4 +158,139 @@ func podWebhookController(cb client.Client) (*PodAdmissionWebhook, context.Conte
 	}
 
 	return r, ctx, nil
+}
+
+func TestPodEventHandler_OnUpdate(t *testing.T) {
+	// Proxy workload
+	p := testhelpers.BuildAuthProxyWorkload(types.NamespacedName{
+		Namespace: "default",
+		Name:      "test",
+	}, "project:region:db")
+	addFinalizers(p)
+	addSelectorWorkload(p, "Deployment", "app", "webapp")
+
+	// Deployment that matches the proxy
+	dMatch := testhelpers.BuildDeployment(types.NamespacedName{
+		Namespace: "default",
+		Name:      "test",
+	}, "webapp")
+	dMatch.ObjectMeta.Labels = map[string]string{"app": "webapp"}
+
+	// Deployment that does not match the proxy
+	dNoMatch := testhelpers.BuildDeployment(types.NamespacedName{
+		Namespace: "default",
+		Name:      "test",
+	}, "webapp")
+	dNoMatch.ObjectMeta.Labels = map[string]string{"app": "other"}
+
+	data := []struct {
+		name                 string
+		d                    *appsv1.Deployment
+		wantNotFound         bool
+		setPodError          bool
+		setSidecarContainers bool
+	}{
+		{
+			name:         "matching pod with error gets deleted",
+			d:            dMatch,
+			setPodError:  true,
+			wantNotFound: true,
+		},
+		{
+			name:         "matching pod with no error",
+			d:            dMatch,
+			setPodError:  false,
+			wantNotFound: false,
+		},
+		{
+			name:         "no matching workload, pod ok",
+			d:            dNoMatch,
+			setPodError:  false,
+			wantNotFound: false,
+		},
+		{
+			name:         "no matching workload, pod error",
+			d:            dNoMatch,
+			setPodError:  true,
+			wantNotFound: false,
+		},
+		{
+			name:                 "matching workload, pod error, has containers",
+			d:                    dNoMatch,
+			setPodError:          true,
+			setSidecarContainers: true,
+			wantNotFound:         false,
+		},
+		{
+			name:                 "matching workload, pod ok, has containers",
+			d:                    dNoMatch,
+			setPodError:          false,
+			setSidecarContainers: true,
+			wantNotFound:         false,
+		},
+	}
+
+	for _, tc := range data {
+		t.Run(tc.name, func(t *testing.T) {
+
+			cb, scheme, err := clientBuilder()
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			rs, hash, err := testhelpers.BuildDeploymentReplicaSet(tc.d, scheme)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			pods, err := testhelpers.BuildDeploymentReplicaSetPods(tc.d, rs, hash, scheme)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if tc.setPodError {
+				pods[0].Status.ContainerStatuses = []corev1.ContainerStatus{{
+					Name:  pods[0].Spec.Containers[0].Name,
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackoff"}},
+				}}
+			}
+
+			cb = cb.WithObjects(p)
+			cb = cb.WithObjects(tc.d)
+			cb = cb.WithObjects(rs)
+
+			for _, p := range pods {
+				cb = cb.WithObjects(p)
+			}
+			c := cb.Build()
+			h, ctx := podEventHandler(c)
+			if tc.setSidecarContainers {
+				h.u.ConfigureWorkload(&workload.PodWorkload{Pod: pods[0]}, []*cloudsqlapi.AuthProxyWorkload{p})
+			}
+
+			h.OnAdd(pods[0])
+
+			var deletedPod corev1.Pod
+			err = c.Get(ctx, client.ObjectKeyFromObject(pods[0]), &deletedPod)
+
+			if !tc.wantNotFound && errors.IsNotFound(err) {
+				t.Fatalf("want not found error, got %v", err)
+			}
+			if tc.wantNotFound && !errors.IsNotFound(err) {
+				t.Fatalf("want no error, found error, got %v", err)
+			}
+
+		})
+	}
+
+}
+
+func podEventHandler(c client.Client) (*PodEventHandler, context.Context) {
+	ctx := log.IntoContext(context.Background(), logger)
+	r := &PodEventHandler{
+		ctx: context.Background(),
+		c:   c,
+		u:   workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage),
+		l:   logr.New(log.NullLogSink{}),
+	}
+	return r, ctx
 }

--- a/internal/controller/pod_controller_test.go
+++ b/internal/controller/pod_controller_test.go
@@ -262,7 +262,7 @@ func TestPodEventHandler_OnUpdate(t *testing.T) {
 				cb = cb.WithObjects(p)
 			}
 			c := cb.Build()
-			h, ctx := podEventHandler(c)
+			h, ctx := podEventHandlerForTest(c)
 			if tc.setSidecarContainers {
 				h.u.ConfigureWorkload(&workload.PodWorkload{Pod: pods[0]}, []*cloudsqlapi.AuthProxyWorkload{p})
 			}
@@ -284,13 +284,12 @@ func TestPodEventHandler_OnUpdate(t *testing.T) {
 
 }
 
-func podEventHandler(c client.Client) (*PodEventHandler, context.Context) {
+func podEventHandlerForTest(c client.Client) (*podEventHandler, context.Context) {
 	ctx := log.IntoContext(context.Background(), logger)
-	r := &PodEventHandler{
-		ctx: context.Background(),
-		c:   c,
-		u:   workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage),
-		l:   logr.New(log.NullLogSink{}),
-	}
+	r := newPodEventHandler(
+		context.Background(),
+		c,
+		workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage),
+		logr.New(log.NullLogSink{}))
 	return r, ctx
 }

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -103,11 +103,6 @@ func RegisterPodWebhook(mgr ctrl.Manager, u *workload.Updater) error {
 // registerPodInformer sets up the informer so that the operator is
 // notified on all changes to all pod resources.
 func registerPodInformer(mgr ctrl.Manager, u *workload.Updater) error {
-	h := &PodEventHandlerRunner{
-		u:   u,
-		l:   ctrl.Log.WithName("pod-informer"),
-		mgr: mgr,
-	}
-
+	h := newPodEventHandlerRunner(mgr, u, ctrl.Log.WithName("pod-informer"))
 	return mgr.Add(h)
 }

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -71,6 +71,11 @@ func SetupManagers(mgr manager.Manager, userAgent, defaultProxyImage string) err
 		setupLog.Error(err, "unable to create workload admission webhook controller")
 		return err
 	}
+	err = registerPodInformer(mgr, u)
+	if err != nil {
+		setupLog.Error(err, "unable to create pod informer")
+		return err
+	}
 
 	// Add the runnable task that will upgrade the proxy image on workloads with
 	// default container image when  the operator first starts.
@@ -93,4 +98,16 @@ func RegisterPodWebhook(mgr ctrl.Manager, u *workload.Updater) error {
 		}})
 
 	return nil
+}
+
+// registerPodInformer sets up the informer so that the operator is
+// notified on all changes to all pod resources.
+func registerPodInformer(mgr ctrl.Manager, u *workload.Updater) error {
+	h := &PodEventHandler{
+		u:   u,
+		l:   ctrl.Log.WithName("pod-informer"),
+		mgr: mgr,
+	}
+
+	return mgr.Add(h)
 }

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -36,7 +36,7 @@ func InitScheme(scheme *runtime.Scheme) {
 	//+kubebuilder:scaffold:scheme
 }
 
-// SetupManagers was moved out of ../main.go to here so that it can be invoked
+// SetupManagers was moved out of ../main.go here so that it can be invoked
 // from the testintegration tests AND from the actual operator.
 func SetupManagers(mgr manager.Manager, userAgent, defaultProxyImage string) error {
 	u := workload.NewUpdater(userAgent, defaultProxyImage)
@@ -71,7 +71,10 @@ func SetupManagers(mgr manager.Manager, userAgent, defaultProxyImage string) err
 		setupLog.Error(err, "unable to create workload admission webhook controller")
 		return err
 	}
-	err = registerPodInformer(mgr, u)
+
+	// Register the podDeleteController, which will listen for pod changes and
+	// delete misconfigured pods that in a waiting or error state.
+	_, err = newPodDeleteController(mgr, u)
 	if err != nil {
 		setupLog.Error(err, "unable to create pod informer")
 		return err
@@ -98,11 +101,4 @@ func RegisterPodWebhook(mgr ctrl.Manager, u *workload.Updater) error {
 		}})
 
 	return nil
-}
-
-// registerPodInformer sets up the informer so that the operator is
-// notified on all changes to all pod resources.
-func registerPodInformer(mgr ctrl.Manager, u *workload.Updater) error {
-	h := newPodEventHandlerRunner(mgr, u, ctrl.Log.WithName("pod-informer"))
-	return mgr.Add(h)
 }

--- a/internal/controller/setup.go
+++ b/internal/controller/setup.go
@@ -103,7 +103,7 @@ func RegisterPodWebhook(mgr ctrl.Manager, u *workload.Updater) error {
 // registerPodInformer sets up the informer so that the operator is
 // notified on all changes to all pod resources.
 func registerPodInformer(mgr ctrl.Manager, u *workload.Updater) error {
-	h := &PodEventHandler{
+	h := &PodEventHandlerRunner{
 		u:   u,
 		l:   ctrl.Log.WithName("pod-informer"),
 		mgr: mgr,


### PR DESCRIPTION
The pod cannot be configured to reliably instrument every single pod creation event due to limitations in the K8s API. 
Thus, the operator needs to listen for pod create and update events, to check if the pod is configured correctly. If the
pod is not configured correctly, and the pod is in an error or waiting state, the operator will delete the pod so that it can
be replaced. The replacement pod will be correctly configured by the webhook as it is created. 

Fixes #337