### PR TITLE
chore: adjust file permissions for kubeconfig.json files 

### DIFF
--- a/infra/resources/gke_cluster.tf
+++ b/infra/resources/gke_cluster.tf
@@ -130,4 +130,5 @@ locals {
 resource "local_file" "kubeconfig" {
   content  = yamlencode(local.kubeconfig)
   filename = var.kubeconfig_path
+  file_permission = "0600"
 }

--- a/infra/resources/private_gke_cluster.tf
+++ b/infra/resources/private_gke_cluster.tf
@@ -134,4 +134,5 @@ locals {
 resource "local_file" "private_kubeconfig" {
   content  = yamlencode(local.private_kubeconfig)
   filename = var.private_kubeconfig_path
+  file_permission = "0600"
 }


### PR DESCRIPTION
The kubeconfig files should only be user readable for the current user. This change prevents
kubernetes clients from printing out console warnings during e2e test.