### PR TITLE
fix: Case issue with pod State (#386)

### DIFF
--- a/internal/controller/pod_controller.go
+++ b/internal/controller/pod_controller.go
@@ -230,7 +230,7 @@ func (r *podDeleteController) Reconcile(ctx context.Context, req ctrl.Request) (
 }
 
 // handlePodChanged Deletes pods that meet the following criteria:
-// 1. The pod is in Error or CrashLoopBackoff state.
+// 1. The pod is in Error or CrashLoopBackOff state.
 // 2. The pod matches one or more AuthProxyWorkload resources.
 // 3. The pod is missing one or more proxy sidecar containers for the resources.
 func (r *podDeleteController) handlePodChanged(ctx context.Context, pod *corev1.Pod) error {

--- a/internal/controller/pod_controller_test.go
+++ b/internal/controller/pod_controller_test.go
@@ -247,7 +247,7 @@ func TestPodDeleteController(t *testing.T) {
 			if tc.setPodError {
 				pods[0].Status.ContainerStatuses = []corev1.ContainerStatus{{
 					Name:  pods[0].Spec.Containers[0].Name,
-					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackoff"}},
+					State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
 				}}
 			}
 

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -242,8 +242,8 @@ func (u *Updater) CheckWorkloadContainers(wl *PodWorkload, matches []*cloudsqlap
 		if cs.State.Terminated != nil && cs.State.Terminated.Reason == "Error" {
 			return fmt.Errorf("pod is in an error state and missing sidecar containers %v", missingSidecars)
 		}
-		if cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackoff" {
-			return fmt.Errorf("pod is in a CrashLoopBackoff state and missing sidecar containers %v", missingSidecars)
+		if cs.State.Waiting != nil && cs.State.Waiting.Reason == "CrashLoopBackOff" {
+			return fmt.Errorf("pod is in a CrashLoopBackOff state and missing sidecar containers %v", missingSidecars)
 		}
 	}
 

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -1058,7 +1058,7 @@ func TestUpdater_CheckWorkloadContainers(t *testing.T) {
 	}
 	wlCfgWait.Pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
 		Name:  wlCfgWait.Pod.Spec.Containers[0].Name,
-		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackoff"}},
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
 	}}
 
 	// Pod configuration says it is running and is missing its proxy containers
@@ -1079,7 +1079,7 @@ func TestUpdater_CheckWorkloadContainers(t *testing.T) {
 	wlCfgMissingWait := podWorkload()
 	wlCfgMissingWait.Pod.Status.ContainerStatuses = []corev1.ContainerStatus{{
 		Name:  wlCfgMissingWait.Pod.Spec.Containers[0].Name,
-		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackoff"}},
+		State: corev1.ContainerState{Waiting: &corev1.ContainerStateWaiting{Reason: "CrashLoopBackOff"}},
 	}}
 
 	// Pod configuration says it is in error and is missing one of the 2 sidecar


### PR DESCRIPTION
The case of "off" in "CrashLoopBackoff" needs to be capitalized in order for the comparison check to match in podspec_updates.go

Fixes #386