### PR TITLE
feat: Configure proxy container for graceful termination

### DIFF
--- a/internal/testhelpers/resources.go
+++ b/internal/testhelpers/resources.go
@@ -295,6 +295,13 @@ func BuildJob(name types.NamespacedName, appLabel string) *batchv1.Job {
 		},
 	}
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+	podCmd := fmt.Sprintf("echo Container 1 is Running \n"+
+		"sleep %d \n"+
+		"for url in $CSQL_QUIT_URLS ; do \n"+
+		"   wget --post-data '' $url \n"+
+		"done", 30)
+	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", podCmd}
+
 	return job
 }
 
@@ -322,6 +329,12 @@ func BuildCronJob(name types.NamespacedName, appLabel string) *batchv1.CronJob {
 		},
 	}
 	job.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
+	podCmd := fmt.Sprintf("echo Container 1 is Running \n"+
+		"sleep %d \n"+
+		"for url in $CSQL_QUIT_URLS ; do \n"+
+		"   wget --post-data '' $url \n"+
+		"done", 30)
+	job.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", podCmd}
 	return job
 
 }
@@ -693,6 +706,10 @@ func (cc *TestCaseClient) ConfigureResources(proxy *cloudsqlapi.AuthProxyWorkloa
 			Requests: map[corev1.ResourceName]resource.Quantity{
 				corev1.ResourceCPU: *resource.NewMilliQuantity(500, resource.DecimalExponent),
 			},
+		},
+		AdminServer: &cloudsqlapi.AdminServerSpec{
+			Port:       9092,
+			EnableAPIs: []string{"QuitQuitQuit"},
 		},
 	}
 }

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -48,10 +48,6 @@ const (
 	// DefaultHealthCheckPort is the used by the proxy to expose prometheus
 	// and kubernetes health checks.
 	DefaultHealthCheckPort int32 = 9801
-
-	// DefaultAdminPort is the used by the proxy to expose prometheus
-	// and kubernetes health checks.
-	DefaultAdminPort int32 = 9802
 )
 
 var l = logf.Log.WithName("internal.workload")
@@ -815,6 +811,9 @@ func (s *updateState) addHealthCheck(p *cloudsqlapi.AuthProxyWorkload, c *corev1
 	s.addProxyContainerEnvVar(p, "CSQL_PROXY_HTTP_PORT", fmt.Sprintf("%d", port))
 	s.addProxyContainerEnvVar(p, "CSQL_PROXY_HTTP_ADDRESS", "0.0.0.0")
 	s.addProxyContainerEnvVar(p, "CSQL_PROXY_HEALTH_CHECK", "true")
+	// For graceful exits as a sidecar, the proxy should exit with exit code 0
+	// when it receives a SIGTERM.
+	s.addProxyContainerEnvVar(p, "CSQL_PROXY_EXIT_ZERO_ON_SIGTERM", "true")
 }
 
 func (s *updateState) addAdminServer(p *cloudsqlapi.AuthProxyWorkload) {

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -535,11 +535,12 @@ func TestProxyCLIArgs(t *testing.T) {
 				}},
 			},
 			wantWorkloadEnv: map[string]string{
-				"CSQL_PROXY_STRUCTURED_LOGS": "true",
-				"CSQL_PROXY_HEALTH_CHECK":    "true",
-				"CSQL_PROXY_HTTP_PORT":       fmt.Sprintf("%d", workload.DefaultHealthCheckPort),
-				"CSQL_PROXY_HTTP_ADDRESS":    "0.0.0.0",
-				"CSQL_PROXY_USER_AGENT":      "cloud-sql-proxy-operator/dev",
+				"CSQL_PROXY_STRUCTURED_LOGS":      "true",
+				"CSQL_PROXY_HEALTH_CHECK":         "true",
+				"CSQL_PROXY_EXIT_ZERO_ON_SIGTERM": "true",
+				"CSQL_PROXY_HTTP_PORT":            fmt.Sprintf("%d", workload.DefaultHealthCheckPort),
+				"CSQL_PROXY_HTTP_ADDRESS":         "0.0.0.0",
+				"CSQL_PROXY_USER_AGENT":           "cloud-sql-proxy-operator/dev",
 			},
 		},
 		{
@@ -691,7 +692,6 @@ func TestProxyCLIArgs(t *testing.T) {
 			},
 		},
 		{
-			desc: "No admin port enabled when AdminServerSpec is nil",
 			proxySpec: cloudsqlapi.AuthProxyWorkloadSpec{
 				AuthProxyContainer: &cloudsqlapi.AuthProxyContainerSpec{},
 				Instances: []cloudsqlapi.InstanceSpec{{
@@ -705,7 +705,6 @@ func TestProxyCLIArgs(t *testing.T) {
 			wantWorkloadEnv: map[string]string{
 				"CSQL_PROXY_HEALTH_CHECK": "true",
 			},
-			dontWantEnvSet: []string{"CSQL_PROXY_DEBUG", "CSQL_PROXY_ADMIN_PORT"},
 		},
 		{
 			desc: "port conflict with other instance causes error",

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -915,7 +916,7 @@ func TestPodTemplateAnnotations(t *testing.T) {
 
 }
 
-func TestQuitUrlEnvVar(t *testing.T) {
+func TestQuitURLEnvVar(t *testing.T) {
 
 	var (
 		u = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
@@ -936,10 +937,14 @@ func TestQuitUrlEnvVar(t *testing.T) {
 	csqls[1].ObjectMeta.Generation = 2
 	csqls[2].ObjectMeta.Generation = 3
 
-	var wantQuitUrlsEnv = fmt.Sprintf(
-		"http://localhost:%d/quitquitquit http://localhost:%d/quitquitquit http://localhost:%d/quitquitquit", workload.DefaultAdminPort,
-		workload.DefaultAdminPort+1,
-		workload.DefaultAdminPort+2)
+	var wantQuitURLSEnv = strings.Join(
+		[]string{
+			fmt.Sprintf("http://localhost:%d/quitquitquit", workload.DefaultAdminPort),
+			fmt.Sprintf("http://localhost:%d/quitquitquit", workload.DefaultAdminPort+1),
+			fmt.Sprintf("http://localhost:%d/quitquitquit", workload.DefaultAdminPort+2),
+		},
+		" ",
+	)
 
 	// update the containers
 	err := configureProxies(u, wl, csqls)
@@ -952,16 +957,14 @@ func TestQuitUrlEnvVar(t *testing.T) {
 	if err != nil {
 		t.Fatal("can't find env var", err)
 	}
-	if ev.Value != wantQuitUrlsEnv {
-		t.Fatal("got", ev.Value, "want", wantQuitUrlsEnv)
+	if ev.Value != wantQuitURLSEnv {
+		t.Fatal("got", ev.Value, "want", wantQuitURLSEnv)
 	}
 }
 
 func TestPreStopHook(t *testing.T) {
 
-	var (
-		u = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
-	)
+	var u = workload.NewUpdater("cloud-sql-proxy-operator/dev", workload.DefaultProxyImage)
 
 	// Create a pod
 	wl := podWorkload()


### PR DESCRIPTION
Add the following configuration to the workload pods so that the proxy can gracefully exit
when the main container is done.

Configure the proxy container to exit 0 when it is terminated. Send a SIGTERM to the proxy container. We want 
the proxy to exit with code 0, indicating a clean termination. Without this change the proxy container would 
exit with exit code 140 (meaning terminated), which would cause kubernetes to report the 
pod as "exited in an error state."

Configure a workload lifecycle handler so that kubernetes calls GET /quitquitquit before terminating the proxy container.
This should give the proxy container the chance to exit gracefully before kubernetes sends a SIGTERM to the 
proxy process. 

Always enable the /quitquitquit proxy api. 

Always set the CSQL_QUIT_URLS environment variable to a space-separated list of proxy quitquitquit urls. This way, when
the main workload container is ready to exit, it can   on workload pods. When a job or cronjob's main process 
is done, that container can iterate over

```
echo Starting job

# execute the job process
run_job

# Tell proxy containers to shut down gracefully
for url in $CSQL_QUIT_URLS ; do 
   wget --post-data '' $url
done
```

Fixes #361
