### PR TITLE
doc: include example resource requests

### DIFF
--- a/docs/examples/deployment-mssql-tcp.yaml
+++ b/docs/examples/deployment-mssql-tcp.yaml
@@ -25,6 +25,20 @@ kind: AuthProxyWorkload
 metadata:
   name: authproxyworkload-sample
 spec:
+  authProxyContainer:
+    # Resource configuration depends on an application's requirements. You
+    # should adjust the following values based on what your application
+    # needs. For details, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    resources:
+      requests:
+        # The proxy's CPU use scales linearly with the amount of IO between
+        # the database and the application. Adjust this value based on your
+        # application's requirements.
+        cpu: "1"
+        # The proxy's memory use scales linearly with the number of active
+        # connections. Fewer open connections will use less memory. Adjust
+        # this value based on your application's requirements.
+        memory: "2Gi"
   workloadSelector:
     kind: "Deployment" # Applies to a "Deployment"
     name: "gke-cloud-sql-app" # named 'gke-cloud-sql-app'

--- a/docs/examples/deployment-mysql-tcp.yaml
+++ b/docs/examples/deployment-mysql-tcp.yaml
@@ -25,6 +25,20 @@ kind: AuthProxyWorkload
 metadata:
   name: authproxyworkload-sample
 spec:
+  authProxyContainer:
+    # Resource configuration depends on an application's requirements. You
+    # should adjust the following values based on what your application
+    # needs. For details, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    resources:
+      requests:
+        # The proxy's CPU use scales linearly with the amount of IO between
+        # the database and the application. Adjust this value based on your
+        # application's requirements.
+        cpu: "1"
+        # The proxy's memory use scales linearly with the number of active
+        # connections. Fewer open connections will use less memory. Adjust
+        # this value based on your application's requirements.
+        memory: "2Gi"
   workloadSelector:
     kind: "Deployment" # Applies to a "Deployment"
     name: "gke-cloud-sql-app" # named 'gke-cloud-sql-app'

--- a/docs/examples/deployment-postgres-tcp.yaml
+++ b/docs/examples/deployment-postgres-tcp.yaml
@@ -25,6 +25,20 @@ kind: AuthProxyWorkload
 metadata:
   name: authproxyworkload-sample
 spec:
+  authProxyContainer:
+    # Resource configuration depends on an application's requirements. You
+    # should adjust the following values based on what your application
+    # needs. For details, see https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
+    resources:
+      requests:
+        # The proxy's CPU use scales linearly with the amount of IO between
+        # the database and the application. Adjust this value based on your
+        # application's requirements.
+        cpu: "1"
+        # The proxy's memory use scales linearly with the number of active
+        # connections. Fewer open connections will use less memory. Adjust
+        # this value based on your application's requirements.
+        memory: "2Gi"
   workloadSelector:
     kind: "Deployment" # Applies to a "Deployment"
     name: "gke-cloud-sql-app" # named 'gke-cloud-sql-app'


### PR DESCRIPTION
Fixes #433 

Adds resource allocation configurations to the examples. The resource requests are configured with the side-car container default resource request values. Follows the approach on this [PR](https://github.com/GoogleCloudPlatform/cloud-sql-proxy/pull/774) 

 

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR