### PR TITLE
chore: Fix yaml formatter so that it only formats the config/ directory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -124,8 +124,9 @@ go_fmt: # Automatically formats go files
 	go mod tidy
 	go run golang.org/x/tools/cmd/goimports@latest -w .
 
-yaml_fmt: # Automatically formats all yaml files
-	go run github.com/UltiRequiem/yamlfmt@latest -w $(shell find . -iname '*.yaml' -or -iname '*.yml' | grep -v -e '^./bin/' | grep -v -e '^./.github/workflows/')
+yaml_fmt: # Automatically format config/ to make generated and handwritten k8s yaml files consistent
+	go run github.com/UltiRequiem/yamlfmt@latest -w \
+		$(shell find ./config -iname '*.yaml' -or -iname '*.yml') $(shell find ./installer -iname '*.yaml' -or -iname '*.yml')
 
 .PHONY: add_copyright_header
 add_copyright_header: # Add the copyright header


### PR DESCRIPTION
We need to automatically format the yaml in config/ because some of it is generated
by controller-runtime and kubebuilder, some of it is hand-written. The formatter helps us
preserve the consistency and minimize noisy diffs when we upgrade the tools that generate yaml. 

However, we don't want to format the hand-written yaml used elsewhere in this project as tool configuration
and example docs. The yaml formatter makes the yaml consistent, but not as readable. 