### PR TITLE
fix: Correct the name of the quit url envvar CSQL_PROXY_QUIT_URLS.

### DIFF
--- a/internal/testhelpers/resources.go
+++ b/internal/testhelpers/resources.go
@@ -297,7 +297,7 @@ func BuildJob(name types.NamespacedName, appLabel string) *batchv1.Job {
 	job.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 	podCmd := fmt.Sprintf("echo Container 1 is Running \n"+
 		"sleep %d \n"+
-		"for url in $CSQL_QUIT_URLS ; do \n"+
+		"for url in $CSQL_PROXY_QUIT_URLS ; do \n"+
 		"   wget --post-data '' $url \n"+
 		"done", 30)
 	job.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", podCmd}
@@ -331,7 +331,7 @@ func BuildCronJob(name types.NamespacedName, appLabel string) *batchv1.CronJob {
 	job.Spec.JobTemplate.Spec.Template.Spec.RestartPolicy = corev1.RestartPolicyNever
 	podCmd := fmt.Sprintf("echo Container 1 is Running \n"+
 		"sleep %d \n"+
-		"for url in $CSQL_QUIT_URLS ; do \n"+
+		"for url in $CSQL_PROXY_QUIT_URLS ; do \n"+
 		"   wget --post-data '' $url \n"+
 		"done", 30)
 	job.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Command = []string{"sh", "-c", podCmd}

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -408,7 +408,7 @@ func (s *updateState) addQuitEnvVar() {
 
 	s.addEnvVar(nil, managedEnvVar{
 		OperatorManagedValue: corev1.EnvVar{
-			Name:  "CSQL_QUIT_URLS",
+			Name:  "CSQL_PROXY_QUIT_URLS",
 			Value: v,
 		}})
 }

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -1015,7 +1015,7 @@ func TestQuitURLEnvVar(t *testing.T) {
 	}
 
 	// test that envvar was set
-	ev, err := findEnvVar(wl, "busybox", "CSQL_QUIT_URLS")
+	ev, err := findEnvVar(wl, "busybox", "CSQL_PROXY_QUIT_URLS")
 	if err != nil {
 		t.Fatal("can't find env var", err)
 	}


### PR DESCRIPTION
All proxy and operator-related environment variables need to use the prefix CSQL_PROXY_ for consistency. 

Related to #361 