### PR TITLE
chore: Make it remove the 'tests:run-unit' label.

### DIFF
--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -60,6 +60,9 @@
 - name: 'tests: run'
   color: 3DED97
   description: Label to trigger Github Action tests.
+- name: 'tests: run-unit'
+  color: 3DED97
+  description: Label to trigger Github Action unit tests.
 - name: 'flakybot: flaky'
   color: 86d9d7
   description: Tells the Flaky Bot not to close or comment on this issue.

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,6 +44,16 @@ jobs:
             } catch (e) {
               console.log('Failed to remove label. Another job may have already removed it!');
             }
+            try {
+              await github.rest.issues.removeLabel({
+                name: 'tests: run-unit',
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number
+              });
+            } catch (e) {
+              console.log('Failed to remove label. Another job may have already removed it!');
+            }
       - name: Setup Go
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3.5.0
         with:


### PR DESCRIPTION
I added a new test trigger when the label 'tests: run-unit' is added. This is used for deps builds so that they don't run the e2e tests. 