### PR TITLE
chore: Configure renovate to group gomod updates in a single PR.

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -48,9 +48,13 @@
       "groupName": "Build Tools"
     },
     {
-      "groupName": "Non-major dependency updates",
+      "groupName": "Non-major go dependency updates",
       "matchManagers": ["gomod"],
       "matchUpdateTypes": ["minor", "patch"]
+    },
+    {
+      "groupName": "Non-major other dependency updates",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"]
     }
   ],
   "force": {

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,6 +7,7 @@
   "ignorePresets": [
     ":semanticPrefixFixDepsChoreOthers"
   ],
+  "commitMessagePrefix": "deps: ",
   "prConcurrentLimit": 0,
   "rebaseWhen": "behind-base-branch",
   "dependencyDashboard": true,
@@ -22,12 +23,6 @@
         "major"
       ],
       "enabled": false
-    },
-    {
-      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
-      "automerge": true,
-      "automergeType": "pr",
-      "automergeStrategy": "rebase"
     },
     {
       "matchManagers": ["github-actions"],
@@ -51,6 +46,11 @@
         "^hashicorp/terraform"
       ],
       "groupName": "Build Tools"
+    },
+    {
+      "groupName": "Non-major dependency updates",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"]
     }
   ],
   "force": {


### PR DESCRIPTION
This will make sure that Renovate puts all the dependency updates in a single PR, rather than 1 per dependency.