### PR TITLE
fix(examples): do not manually set env vars in deployment

### DIFF
--- a/docs/examples/deployment-mssql-tcp.yaml
+++ b/docs/examples/deployment-mssql-tcp.yaml
@@ -46,6 +46,7 @@ spec:
     - connectionString: "my-project:us-central1:instance" # from your Cloud SQL Database instance
       portEnvName: "DB_PORT" # Will set an env var named 'DB_PORT' to the database port
       hostEnvName: "DB_HOST" # Will set an env var named 'DB_HOST' to the proxy's host, 127.0.0.1
+      privateIP: true # Optional - Will use the private IP instead of public IP
 ---
 ##
 # Put the database name, username, and password into a kubernetes secret
@@ -103,10 +104,6 @@ spec:
             - "-c"
             - "sleep 10 ; /opt/mssql-tools/bin/sqlcmd -S \"tcp:$DB_HOST,$DB_PORT\" -U $DB_USER -P $DB_PASS -Q \"use $DB_NAME ; select 1 ;\" ; sleep 3600"
           env:
-            - name: DB_HOST
-              value: "set-by-operator"
-            - name: DB_PORT
-              value: "set-by-operator"
             - name: DB_USER
               valueFrom:
                 secretKeyRef:

--- a/docs/examples/deployment-mysql-tcp.yaml
+++ b/docs/examples/deployment-mysql-tcp.yaml
@@ -46,6 +46,7 @@ spec:
     - connectionString: "my-project:us-central1:instance" # from your Cloud SQL Database instance
       portEnvName: "DB_PORT" # Will set an env var named 'DB_PORT' to the database port
       hostEnvName: "DB_HOST" # Will set an env var named 'DB_HOST' to the proxy's host, 127.0.0.1
+      privateIP: true # Optional - Will use the private IP instead of public IP
 ---
 ##
 # Put the database name, username, and password into a kubernetes secret
@@ -103,10 +104,6 @@ spec:
             - "-c"
             - "sleep 10 ; mysql --host=$DB_HOST --port=$DB_PORT --user=$DB_USER --password=$DB_PASS --database=$DB_NAME '--execute=select now() ; sleep 3600"
           env:
-            - name: DB_HOST
-              value: "set-by-operator"
-            - name: DB_PORT
-              value: "set-by-operator"
             - name: DB_USER
               valueFrom:
                 secretKeyRef:

--- a/docs/examples/deployment-postgres-tcp.yaml
+++ b/docs/examples/deployment-postgres-tcp.yaml
@@ -46,6 +46,7 @@ spec:
     - connectionString: "my-project:us-central1:instance" # from your Cloud SQL Database instance
       portEnvName: "DB_PORT" # Will set an env var named 'DB_PORT' to the database port
       hostEnvName: "DB_HOST" # Will set an env var named 'DB_HOST' to the proxy's host, 127.0.0.1
+      privateIP: true # Optional - Will use the private IP instead of public IP
 ---
 ##
 # Put the database name, username, and password into a kubernetes secret
@@ -103,10 +104,6 @@ spec:
             - "-c"
             - "sleep 10 ; psql --host=$DB_HOST --port=$DB_PORT --username=$DB_USER '--command=select 1' --echo-queries --dbname=$DB_NAME ; sleep 3600"
           env:
-            - name: DB_HOST
-              value: "set-by-operator"
-            - name: DB_PORT
-              value: "set-by-operator"
             - name: DB_USER
               valueFrom:
                 secretKeyRef:

--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -112,10 +112,6 @@ spec:
         env:
         - name: PORT
           value: "8080"
-        - name: INSTANCE_HOST
-          value: "set-by-proxy"
-        - name: DB_PORT
-          value: "set-by-proxy"
         - name: DB_USER
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Hello,

This PR aims to fix one issue and apply one finOps best practices:

- Delete env vars `DB_PORT` and `DB_HOST` from `deployment` because they are both automatically set by the operator
- Add the `privateIP: true` to reduce network billing

I also feel the `AuthProxyWorkload` should apply to a label selector so it could match multiple deployments, instead of a single deployment name. I did not include this change in this PR as it is not relevant to how the CSP works :-)


```
  workloadSelector:
    kind: Deployment
    selector:
      matchLabels:
        cloud-proxy-sql: "true"
```


Regards,
Sebastien.

- [ ] Tests pass
- [ ] Appropriate changes to README are included in PR