### PR TITLE
feat: Specify the security context on the proxy container.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -50,6 +50,7 @@ _Appears in:_
 | --- | --- | --- | --- |
 | `container` _[Container](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#container-v1-core)_ | Container is debugging parameter that when specified will override the<br />proxy container with a completely custom Container spec. |  | Optional: \{\} <br /> |
 | `resources` _[ResourceRequirements](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#resourcerequirements-v1-core)_ | Resources specifies the resources required for the proxy pod. |  | Optional: \{\} <br /> |
+| `securityContext` _[SecurityContext](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#securitycontext-v1-core)_ | SecurityContext specifies the security context for the proxy container. |  | Optional: \{\} <br /> |
 | `telemetry` _[TelemetrySpec](#telemetryspec)_ | Telemetry specifies how the proxy should expose telemetry.<br />Optional, by default |  | Optional: \{\} <br /> |
 | `adminServer` _[AdminServerSpec](#adminserverspec)_ | AdminServer specifies the config for the proxy's admin service which is<br />available to other containers in the same pod. |  |  |
 | `authentication` _[AuthenticationSpec](#authenticationspec)_ | Authentication specifies the config for how the proxy authenticates itself<br />to the Google Cloud API. |  |  |

--- a/internal/api/v1/authproxyworkload_types.go
+++ b/internal/api/v1/authproxyworkload_types.go
@@ -154,6 +154,10 @@ type AuthProxyContainerSpec struct {
 	//+kubebuilder:validation:Optional
 	Resources *corev1.ResourceRequirements `json:"resources,omitempty"`
 
+	// SecurityContext specifies the security context for the proxy container.
+	//+kubebuilder:validation:Optional
+	SecurityContext *corev1.SecurityContext `json:"securityContext,omitempty"`
+
 	// Telemetry specifies how the proxy should expose telemetry.
 	// Optional, by default
 	//+kubebuilder:validation:Optional

--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -737,7 +737,9 @@ func (s *updateState) applyContainerSpec(p *cloudsqlapi.AuthProxyWorkload, c *co
 		// Do not allow privilege escalation
 		AllowPrivilegeEscalation: &f,
 	}
-
+	if p.Spec.AuthProxyContainer != nil && p.Spec.AuthProxyContainer.SecurityContext != nil {
+		c.SecurityContext = p.Spec.AuthProxyContainer.SecurityContext.DeepCopy()
+	}
 	if p.Spec.AuthProxyContainer == nil {
 		return
 	}


### PR DESCRIPTION
This adds a new field to the AuthProxyWorkload spec: `authProxyContainer.securityContext`. This field will override the default security in the auth proxy container. 

Fixes #694
See also #641