### PR TITLE
fix: Update proxy to 2.18.2 to include DNS name fix.

### DIFF
--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -39,7 +39,7 @@ const (
 	// DefaultProxyImage is the latest version of the proxy as of the release
 	// of this operator. This is managed as a dependency. We update this constant
 	// when the Cloud SQL Auth Proxy releases a new version.
-	DefaultProxyImage = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.18.1"
+	DefaultProxyImage = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.18.2"
 
 	// DefaultFirstPort is the first port number chose for an instance listener by the
 	// proxy.


### PR DESCRIPTION
Operator will use the proxy that includes the fix to the check DNS name changed loop. 

See https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/1007
