### PR TITLE
fix: bump dependencies to latest

### DIFF
--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -39,7 +39,7 @@ const (
 	// DefaultProxyImage is the latest version of the proxy as of the release
 	// of this operator. This is managed as a dependency. We update this constant
 	// when the Cloud SQL Auth Proxy releases a new version.
-	DefaultProxyImage = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.18.2"
+	DefaultProxyImage = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.19.0"
 
 	// DefaultFirstPort is the first port number chose for an instance listener by the
 	// proxy.


### PR DESCRIPTION
Bump the depending cloud auth proxy to latest `2.19.0`