### PR TITLE
fix: k8s 1.34 baseline PSA compliance

### DIFF
--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -899,7 +899,6 @@ func (s *updateState) addHealthCheck(p *cloudsqlapi.AuthProxyWorkload, c *corev1
 			HTTPGet: &corev1.HTTPGetAction{
 				Port: intstr.IntOrString{IntVal: adminPort},
 				Path: "/quitquitquit",
-				Host: "localhost",
 			},
 		},
 	}

--- a/internal/workload/podspec_updates_test.go
+++ b/internal/workload/podspec_updates_test.go
@@ -1137,8 +1137,8 @@ func TestPreStopHook(t *testing.T) {
 	if get.Path != "/quitquitquit" {
 		t.Error("got", get.Path, "want", "/quitquitquit")
 	}
-	if get.Host != "localhost" {
-		t.Error("got", get.Host, "want", "localhost")
+	if get.Host != "" {
+		t.Error("got", get.Host, "want empty string (k8s 1.34 baseline PSA compliance)")
 	}
 }
 


### PR DESCRIPTION
Fixes critical issue #739 

Tested on GKE Standard with the following namespace settings:

```
      pod-security.kubernetes.io/audit=baseline                                         
      pod-security.kubernetes.io/enforce=baseline                                                
      pod-security.kubernetes.io/warn=baseline
```