### PR TITLE
fix: Update Auth Proxy version to 2.24.1

### DIFF
--- a/internal/workload/podspec_updates.go
+++ b/internal/workload/podspec_updates.go
@@ -39,7 +39,7 @@ const (
 	// DefaultProxyImage is the latest version of the proxy as of the release
 	// of this operator. This is managed as a dependency. We update this constant
 	// when the Cloud SQL Auth Proxy releases a new version.
-	DefaultProxyImage = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.23.0"
+	DefaultProxyImage = "gcr.io/cloud-sql-connectors/cloud-sql-proxy:2.24.1"
 
 	// DefaultFirstPort is the first port number chose for an instance listener by the
 	// proxy.


### PR DESCRIPTION
This auth proxy includes support for PSC DNS names and Global Write Endpoint.  See  https://github.com/GoogleCloudPlatform/cloud-sql-go-connector/pull/1106